### PR TITLE
Updated Helm URLs and added devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "bash scripts/install-dependencies.sh"
+	"postCreateCommand": "bash .devcontainer/scripts/install-dependencies.sh"
 
 	// Use 'postStartCommand' to run commands after the container is created like starting minikube.
 	// "postStartCommand": "nohup bash -c 'minikube start &' > minikube.log 2>&1",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube
+{
+	"name": "Google Cloud - Teraform",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+	"features": {
+		// "ghcr.io/devcontainers/features/docker-in-docker:2": {
+		// 	"enableNonRootDocker": "true",
+		// 	"moby": "true"
+		// },
+		// "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+		// 	"version": "latest",
+		// 	"helm": "latest",
+		// 	"minikube": "latest"
+		// },
+		"ghcr.io/devcontainers/features/terraform:1": {},
+		// "ghcr.io/bartventer/arch-devcontainer-features/gcloud-cli:1": {}
+	},
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash scripts/install-dependencies.sh"
+
+	// Use 'postStartCommand' to run commands after the container is created like starting minikube.
+	// "postStartCommand": "nohup bash -c 'minikube start &' > minikube.log 2>&1",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/scripts/install-dependencies.sh
+++ b/.devcontainer/scripts/install-dependencies.sh
@@ -1,0 +1,28 @@
+sudo apt-get update
+# Install dependencies for Google Cloud Client
+sudo apt-get install apt-transport-https ca-certificates gnupg curl
+# Install Google Cloud Client
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+sudo apt-get update && sudo apt-get install google-cloud-cli
+# Install Google Cloud Auth Plugin
+gcloud components install gke-gcloud-auth-plugin
+# Install Helm
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+sudo apt-get install apt-transport-https --yes
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt-get update
+sudo apt-get install helm
+# Add Theia Cloud Helm repo.
+helm repo add theia-cloud-remote https://eclipse-theia.github.io/theia-cloud-helm/
+helm repo update
+# Install kubectl dependencies.
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+# Install kubectl.
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
+sudo apt-get update
+sudo apt-get install -y kubectl

--- a/.devcontainer/scripts/install-dependencies.sh
+++ b/.devcontainer/scripts/install-dependencies.sh
@@ -4,7 +4,7 @@ sudo apt-get install apt-transport-https ca-certificates gnupg curl
 # Install Google Cloud Client
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-sudo apt-get update && sudo apt-get install google-cloud-cli
+sudo apt-get update && sudo apt-get install google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
 # Install Google Cloud Auth Plugin
 gcloud components install gke-gcloud-auth-plugin
 # Install Helm

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Older versions (before the introduction of `theia-cloud-crds`) require a manual 
 ### Add & update Theia Cloud helm repo
 
 ```bash
-helm repo add theia-cloud-remote https://github.eclipsesource.com/theia-cloud-helm
+helm repo add theia-cloud-remote https://eclipse-theia.github.io/theia-cloud-helm
 helm repo update
 ```
 

--- a/documentation/Install.md
+++ b/documentation/Install.md
@@ -67,7 +67,7 @@ hosts:
 ### Add & update Theia Cloud helm repo
 
 ```bash
-helm repo add theia-cloud-remote https://github.eclipsesource.com/theia-cloud-helm
+helm repo add theia-cloud-remote https://eclipse-theia.github.io/theia-cloud-helm
 helm repo update
 ```
 

--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -128,7 +128,7 @@ resource "helm_release" "theia-cloud-base" {
   count            = var.install_theia_cloud_base ? 1 : 0
   depends_on       = [helm_release.cert-manager, helm_release.nginx-ingress-controller] # we need to install cert issuers
   name             = "theia-cloud-base"
-  repository       = "https://github.eclipsesource.com/theia-cloud-helm"
+  repository       = "https://eclipse-theia.github.io/theia-cloud-helm"
   chart            = "theia-cloud-base"
   version          = "0.11.1"
   namespace        = "theiacloud"
@@ -144,7 +144,7 @@ resource "helm_release" "theia-cloud-crds" {
   count            = var.install_theia_cloud_crds ? 1 : 0
   depends_on       = [helm_release.theia-cloud-base]
   name             = "theia-cloud-crds"
-  repository       = "https://github.eclipsesource.com/theia-cloud-helm"
+  repository       = "https://eclipse-theia.github.io/theia-cloud-helm"
   chart            = "theia-cloud-crds"
   version          = "0.11.1"
   namespace        = "theiacloud"
@@ -228,7 +228,7 @@ resource "helm_release" "theia-cloud" {
   count            = var.install_theia_cloud ? 1 : 0
   depends_on       = [helm_release.keycloak, helm_release.theia-cloud-crds] # wait for keycloak to make the default cert available
   name             = "theia-cloud"
-  repository       = "https://github.eclipsesource.com/theia-cloud-helm"
+  repository       = "https://eclipse-theia.github.io/theia-cloud-helm"
   chart            = "theia-cloud"
   version          = "0.11.1"
   namespace        = "theiacloud"

--- a/terraform/modules/helm/theia-cloud.yaml
+++ b/terraform/modules/helm/theia-cloud.yaml
@@ -1,7 +1,7 @@
 imagePullPolicy: Always
 
 app:
-  id: asdfghjkl
+  id: theia-cloud
   name: Theia Cloud
 
 demoApplication:

--- a/terraform/modules/helm/theia-cloud.yaml
+++ b/terraform/modules/helm/theia-cloud.yaml
@@ -1,7 +1,7 @@
 imagePullPolicy: Always
 
 app:
-  id: theia-cloud
+  id: asdfghjkl
   name: Theia Cloud
 
 demoApplication:


### PR DESCRIPTION
I was trying out the Theia Cloud Try-Now Terraform and encountered some issues with Helm and also didn't want to install all dependencies locally on my machine. So I propose the following changes:
- Updated Helm URLs to eclipse-theia.github.io.
- Created devcontainer definition with all dependencies for the try-now deployment.