### PR TITLE
Fix lastActivity not being initialized properly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,24 @@
   "version": "0.2.0",
   "configurations": [
     {
+      // This works with terraform config 2-01_try-now
       "type": "java",
-      "name": "Debug Default Operator",
+      "name": "Debug Operator (try-now)",
       "request": "launch",
       "cwd": "${workspaceFolder}/java/operator/org.eclipse.theia.cloud.defaultoperator",
       "mainClass": "org.eclipse.theia.cloud.defaultoperator.DefaultTheiaCloudOperatorLauncher",
       "args": [
+        "--keycloak",
+        "--keycloakURL",
+        "https://${input:minikubeIP}.nip.io/keycloak/",
+        "--keycloakRealm",
+        "TheiaCloud",
+        "--keycloakClientId",
+        "theia-cloud",
         "--instancesHost",
-        "ws.$(minikube.ip).nip.io",
+        "ws.${input:minikubeIP}.nip.io",
+        "--serviceUrl",
+        "https://service.${input:minikubeIP}.nip.io",
         "--cloudProvider",
         "MINIKUBE",
         "--sessionsPerUser",
@@ -19,10 +29,141 @@
         "--storageClassName",
         "default",
         "--requestedStorage",
-        "250Mi"
+        "250Mi",
+        "--bandwidthLimiter",
+        "WONDERSHAPER",
+        "--oAuth2ProxyVersion",
+        "v7.5.1"
       ],
       "vmArgs": "-Dlog4j2.configurationFile=log4j2.xml",
       "preLaunchTask": "Build and Install Operator library"
+    },
+    {
+      // This works with terraform config 2-02_monitor with authentication
+      "type": "java",
+      "name": "Debug Operator (monitor-auth)",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/java/operator/org.eclipse.theia.cloud.defaultoperator",
+      "mainClass": "org.eclipse.theia.cloud.defaultoperator.DefaultTheiaCloudOperatorLauncher",
+      "args": [
+        "--enableMonitor",
+        "--enableActivityTracker",
+        "--keycloak",
+        "--keycloakURL",
+        "https://${input:minikubeIP}.nip.io/keycloak/",
+        "--keycloakRealm",
+        "TheiaCloud",
+        "--keycloakClientId",
+        "theia-cloud",
+        "--instancesHost",
+        "ws.${input:minikubeIP}.nip.io",
+        "--serviceUrl",
+        "https://service.${input:minikubeIP}.nip.io",
+        "--cloudProvider",
+        "MINIKUBE",
+        "--sessionsPerUser",
+        "3",
+        "--appId",
+        "asdfghjkl",
+        "--storageClassName",
+        "default",
+        "--requestedStorage",
+        "250Mi",
+        "--bandwidthLimiter",
+        "WONDERSHAPER",
+        "--oAuth2ProxyVersion",
+        "v7.5.1"
+      ],
+      "vmArgs": "-Dlog4j2.configurationFile=log4j2.xml",
+      "preLaunchTask": "Build and Install Operator library"
+    },
+    {
+      // This works with terraform config 2-02_monitor with no authentication
+      "type": "java",
+      "name": "Debug Operator (monitor-no-auth)",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/java/operator/org.eclipse.theia.cloud.defaultoperator",
+      "mainClass": "org.eclipse.theia.cloud.defaultoperator.DefaultTheiaCloudOperatorLauncher",
+      "args": [
+        "--enableMonitor",
+        "--enableActivityTracker",
+        "--instancesHost",
+        "ws.${input:minikubeIP}.nip.io",
+        "--serviceUrl",
+        "https://service.${input:minikubeIP}.nip.io",
+        "--cloudProvider",
+        "MINIKUBE",
+        "--sessionsPerUser",
+        "3",
+        "--appId",
+        "asdfghjkl",
+        "--storageClassName",
+        "default",
+        "--requestedStorage",
+        "250Mi",
+        "--bandwidthLimiter",
+        "WONDERSHAPER",
+        "--oAuth2ProxyVersion",
+        "v7.5.1"
+      ],
+      "vmArgs": "-Dlog4j2.configurationFile=log4j2.xml",
+      "preLaunchTask": "Build and Install Operator library"
+    },
+    {
+      // This works with terraform config 2-03_try-now_paths
+      "type": "java",
+      "name": "Debug Operator (try-now-paths)",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/java/operator/org.eclipse.theia.cloud.defaultoperator",
+      "mainClass": "org.eclipse.theia.cloud.defaultoperator.DefaultTheiaCloudOperatorLauncher",
+      "args": [
+        "--keycloak",
+        "--keycloakURL",
+        "https://${input:minikubeIP}.nip.io/keycloak/",
+        "--keycloakRealm",
+        "TheiaCloud",
+        "--keycloakClientId",
+        "theia-cloud",
+        "--usePaths",
+        "--instancesPath",
+        "instances",
+        "--instancesHost",
+        "${input:minikubeIP}.nip.io",
+        "--serviceUrl",
+        "https://${input:minikubeIP}.nip.io/service",
+        "--cloudProvider",
+        "MINIKUBE",
+        "--sessionsPerUser",
+        "3",
+        "--appId",
+        "asdfghjkl",
+        "--storageClassName",
+        "default",
+        "--requestedStorage",
+        "250Mi",
+        "--bandwidthLimiter",
+        "WONDERSHAPER",
+        "--oAuth2ProxyVersion",
+        "v7.5.1"
+      ],
+      "vmArgs": "-Dlog4j2.configurationFile=log4j2.xml",
+      "preLaunchTask": "Build and Install Operator library"
+    },
+    {
+      // Attach to the service running (Task: Run Service)
+      "type": "java",
+      "name": "Attach to Service",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": 5005
+    }
+  ],
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "minikubeIP",
+      "description": "Provide your minikube ip address (execute 'minikube ip').",
+      "default": "192.168.59.101"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,33 @@
       "label": "Run Service",
       "type": "shell",
       "command": "mvn",
-      "args": ["compile", "quarkus:dev"],
+      "args": [
+        "compile",
+        "quarkus:dev",
+        "-Dtheia.cloud.app.id=asdfghjkl",
+        "-Dquarkus.http.port=8081",
+        "-Dtheia.cloud.use.keycloak=false"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/java/service/org.eclipse.theia.cloud.service"
+      },
+      "problemMatcher": [],
+      "dependsOn": "Build and Install Common library"
+    },
+    {
+      "label": "Run Service (with keycloak)",
+      "type": "shell",
+      "command": "mvn",
+      "args": [
+        "compile",
+        "quarkus:dev",
+        "-Dtheia.cloud.app.id=asdfghjkl",
+        "-Dquarkus.http.port=8081",
+        "-Dtheia.cloud.use.keycloak=true",
+        "-Dquarkus.oidc.auth-server-url=${input:keycloakURL}",
+        "-Dquarkus.oidc.client-id=theia-cloud",
+        "-Dquarkus.oidc.credentials.secret=publicbutoauth2proxywantsasecret"
+      ],
       "options": {
         "cwd": "${workspaceFolder}/java/service/org.eclipse.theia.cloud.service"
       },
@@ -68,6 +94,14 @@
       },
       "problemMatcher": [],
       "dependsOn": "Build and Install Common library"
+    }
+  ],
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "keycloakURL",
+      "description": "Provide the keycloak url",
+      "default": "https://192.168.59.101.nip.io/keycloak/"
     }
   ]
 }

--- a/documentation/OpenAPI.md
+++ b/documentation/OpenAPI.md
@@ -32,6 +32,8 @@ docker run -p 80:8080 swaggerapi/swagger-ui
 
 Then browse to <http://localhost/> and explore the spec from here: <https://raw.githubusercontent.com/eclipsesource/theia-cloud/main/documentation/openapi.json>
 
+Or explore it from the locally started service: <http://localhost:8081/q/openapi?format=json>.
+
 ## Generate Typescript API
 
 You can generate the typescript client used in the common package.

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/DefaultSessionResourceClient.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/DefaultSessionResourceClient.java
@@ -48,8 +48,6 @@ public class DefaultSessionResourceClient extends BaseResourceClient<Session, Se
         metadata.setName(spec.getName());
         session.setMetadata(metadata);
 
-        updateStatus(correlationId, session, status -> status.setLastActivity(Instant.now().toEpochMilli()));
-
         info(correlationId, "Create Session " + session.getSpec());
         return operation().resource(session).create();
     }

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/ResourceClient.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/ResourceClient.java
@@ -58,6 +58,8 @@ public interface ResourceClient<T extends HasMetadata, L extends KubernetesResou
         info(correlationId, "Edit " + name);
         Resource<T> resource = resource(name);
         if (resource.get() == null) {
+            warn(correlationId, "Resource not found! Could not edit " + name
+                    + ". Was this called before the resource has been created?");
             return null;
         }
         return resource.edit(JavaUtil.toUnary(consumer));
@@ -67,6 +69,8 @@ public interface ResourceClient<T extends HasMetadata, L extends KubernetesResou
         trace(correlationId, "Edit status of " + name);
         Resource<T> resource = resource(name);
         if (resource.get() == null) {
+            warn(correlationId, "Resource " + name
+                    + " not found. Could not update the status. Note that the status of a resource cannot be changed before it is created on the cluster.");
             return null;
         }
         return resource.editStatus(JavaUtil.toUnary(consumer));

--- a/java/operator/README.md
+++ b/java/operator/README.md
@@ -1,0 +1,43 @@
+# Theia Cloud Operator
+
+This folder contains the Java projects for the Theia Cloud operator, including:
+
+- **Default Theia Cloud Operator**: Provides a default implementation of the operator.
+- **Theia Cloud Operator Library**: The key functionality for the Theia Cloud Operator, to be used in your implementation.
+
+## Projects
+
+### Default Theia Cloud Operator
+
+This project implements the default Kubernetes Operator for Theia Cloud.
+
+#### Build and Run
+
+```sh
+mvn clean install
+java -jar target/defaultoperator-0.12.0-SNAPSHOT-jar-with-dependencies.jar
+```
+
+#### Debugging the Default Theia Cloud Operator
+
+To debug the Default Theia Cloud Operator, follow these steps:
+
+- **Set the Replicas**:
+
+  - Set the replicas of the operator in your Theia Cloud installation to 0.
+
+- **Start the Debug Config**:
+
+  - Launch the debug configuration with the appropriate flags for debugging.
+  - There are specific configurations for the [terraform test-configurations](../../terraform/test-configurations/) available.
+  - The configurations will prompt you for your Minikube IP address. To find out the IP address, run the following command in your terminal:
+
+```sh
+     minikube ip
+```
+
+_Note_: Ensure your local `kubectl` is set to the correct namespace (e.g., `theiacloud`), as the debuggable operator will interact with your local Kubernetes cluster.
+
+### Theia Cloud Operator Library
+
+A shared library for building Theia Cloud Kubernetes operators.

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
@@ -21,6 +21,7 @@ import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatMetric;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -191,6 +192,7 @@ public class LazySessionHandler implements SessionHandler {
             client.sessions().updateStatus(correlationId, session, s -> {
                 s.setOperatorStatus(OperatorStatus.HANDLED);
                 s.setOperatorMessage("Service already exists.");
+                s.setLastActivity(Instant.now().toEpochMilli());
             });
             // TODO do not return true if the sessions was in handling state at the start of
             // this handler
@@ -218,6 +220,7 @@ public class LazySessionHandler implements SessionHandler {
                 client.sessions().updateStatus(correlationId, session, s -> {
                     s.setOperatorStatus(OperatorStatus.HANDLED);
                     s.setOperatorMessage("Configmaps already exist.");
+                    s.setLastActivity(Instant.now().toEpochMilli());
                 });
                 // TODO do not return true if the sessions was in handling state at the start of
                 // this handler
@@ -237,6 +240,7 @@ public class LazySessionHandler implements SessionHandler {
             client.sessions().updateStatus(correlationId, session, s -> {
                 s.setOperatorStatus(OperatorStatus.HANDLED);
                 s.setOperatorMessage("Deployment already exists.");
+                s.setLastActivity(Instant.now().toEpochMilli());
             });
             return true;
         }
@@ -275,6 +279,7 @@ public class LazySessionHandler implements SessionHandler {
 
         client.sessions().updateStatus(correlationId, session, s -> {
             s.setOperatorStatus(OperatorStatus.HANDLED);
+            s.setLastActivity(Instant.now().toEpochMilli());
         });
         return true;
     }
@@ -351,9 +356,8 @@ public class LazySessionHandler implements SessionHandler {
         if (!session.getSpec().getUser().equals(workspace.get().getSpec().getUser())) {
             // the workspace is owned by a different user. do not mount and go ephemeral
             // should get prevented by service, but we need to be sure to not expose data
-            LOGGER.error(formatLogMessage(correlationId,
-                    "Workspace is owned by " + workspace.get().getSpec().getUser() + ", but requesting user is "
-                            + session.getSpec().getUser()));
+            LOGGER.error(formatLogMessage(correlationId, "Workspace is owned by " + workspace.get().getSpec().getUser()
+                    + ", but requesting user is " + session.getSpec().getUser()));
             return Optional.empty();
         }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/plugins/MonitorActivityTracker.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/plugins/MonitorActivityTracker.java
@@ -29,10 +29,12 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.client.TheiaCloudClient;
+import org.eclipse.theia.cloud.common.k8s.resource.OperatorStatus;
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
 import org.eclipse.theia.cloud.operator.TheiaCloudOperatorArguments;
@@ -78,7 +80,10 @@ public class MonitorActivityTracker implements OperatorPlugin {
     }
 
     protected void pingAllSessions() {
-        List<Session> sessions = resourceClient.sessions().list();
+        // Only look at handled sessions (handled sessions have a lastActivity)
+        List<Session> sessions = resourceClient.sessions().list().stream()
+                .filter(session -> OperatorStatus.HANDLED.equals(session.getStatus().getOperatorStatus()))
+                .collect(Collectors.toList());
         String correlationId = generateCorrelationId();
 
         LOGGER.debug("Pinging sessions: " + sessions);

--- a/java/service/org.eclipse.theia.cloud.service/README.md
+++ b/java/service/org.eclipse.theia.cloud.service/README.md
@@ -14,6 +14,14 @@ You can run your application in dev mode that enables live coding using:
 
 > **_NOTE:_** Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.
 
+## Debug the service
+
+When you have the service running in dev mode you can use the `Attach to Service` debug config to debug the service.
+
+Check the [OpenAPI documentation](../../../documentation/OpenAPI.md) to see how you can send requests to the service.
+
+_Note_: The landing page will not communicate with this service, as it will be hosted on another address.
+
 ## Packaging and running the application
 
 The application can be packaged using:

--- a/terraform/values/valuesDemo.yaml
+++ b/terraform/values/valuesDemo.yaml
@@ -1,4 +1,4 @@
-imagePullPolicy: Always
+imagePullPolicy: IfNotPresent
 
 app:
   id: asdfghjkl

--- a/terraform/values/valuesMonitor.yaml
+++ b/terraform/values/valuesMonitor.yaml
@@ -1,4 +1,4 @@
-imagePullPolicy: Always
+imagePullPolicy: IfNotPresent
 
 app:
   id: asdfghjkl


### PR DESCRIPTION
- Improve and document debugging of operator and service
- Minor improvement: Local testing values should only pull IfNotPresent
- Fix lastActivity not being initialized properly
    - We need to set it after the resource has been created.
    - Therefore it is now handled by the operator not the service.
    - Add warning in case resources are edited before being applied to the cluster.
    - Only check HANDLED sessions from the activity tracking.
    - Other resources should be cleaned up differently.