### PR TITLE
Update maven repository to new url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,33 +1,33 @@
 name: Bug Report
 description: Create a bug report to help us improve
-labels: bug
+labels: ["bug"]
 body:
-- type: markdown
-  attributes:
-    value: |
-      This template is not meant for security vulnerabilities disclosure. Any such issue, created in this repo, will be deleted on sight.
-      Instead, please report vulnerabilities to [security@theia-cloud.io](mailto:security@theia-cloud.io). For more details, please read [SECURITY.md](https://github.com/eclipsesource/theia-cloud/blob/main/SECURITY.md) in the repository root.
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: Describe the bug
-    description: A clear and concise description of what the bug is.
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: Expected behavior
-    description: A clear and concise description of what you expected to happen.
-- type: input
-  attributes:
-    label: Cluster provider
-    description: The cluster provider (e.g. Minikube, AWS, GKE, Azure, Docker Desktop). Please include your OS when using a local cluster. If you are using Terraform, please include the configuration files if possible.  
-- type: input
-  attributes:
-    label: Version
-    description: The used version. Such as the helm chart version or the commit id the bug was discovered on
-- type: textarea
-  attributes:
-    label: Additional information
-    description: Additional information to analyze the bug such as logs, screenshots, screencasts.
+  - type: markdown
+    attributes:
+      value: |
+        This template is not meant for security vulnerabilities disclosure. Any such issue, created in this repo, will be deleted on sight.
+        Instead, please report vulnerabilities to [security@theia-cloud.io](mailto:security@theia-cloud.io). For more details, please read [SECURITY.md](https://github.com/eclipse-theia/theia-cloud/blob/main/SECURITY.md) in the repository root.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+  - type: input
+    attributes:
+      label: Cluster provider
+      description: The cluster provider (e.g. Minikube, AWS, GKE, Azure, Docker Desktop). Please include your OS when using a local cluster. If you are using Terraform, please include the configuration files if possible.
+  - type: input
+    attributes:
+      label: Version
+      description: The used version. Such as the helm chart version or the commit id the bug was discovered on
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Additional information to analyze the bug such as logs, screenshots, screencasts.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question
-    url: https://github.com/eclipsesource/theia-cloud/discussions
+    url: https://github.com/eclipse-theia/theia-cloud/discussions
     about: Please ask questions on the Theia Cloud discussions page.
   - name: Professional support
     url: https://theia-cloud.io/support/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,47 +4,47 @@
 
 ## [0.11.0] - 2024-07-23
 
-- [common] Add option field to CRDs and increase version to `Session.v1beta8`, `Workspace.v1beta5` and `AppDefinition.v1beta10` [#293](https://github.com/eclipsesource/theia-cloud/pull/293) | [#55](https://github.com/eclipsesource/theia-cloud-helm/pull/55)
-- [java] Separate operator default implementation from library to allow for easier customization [#303](https://github.com/eclipsesource/theia-cloud/pull/303)
-- [node] Unify the existing landing and try now pages to a new ViteJS based landing page [#304](https://github.com/eclipsesource/theia-cloud/pull/304) | [#58](https://github.com/eclipsesource/theia-cloud-helm/pull/58) - contributed on behalf of STMicroelectronics
+- [common] Add option field to CRDs and increase version to `Session.v1beta8`, `Workspace.v1beta5` and `AppDefinition.v1beta10` [#293](https://github.com/eclipse-theia/theia-cloud/pull/293) | [#55](https://github.com/eclipse-theia/theia-cloud-helm/pull/55)
+- [java] Separate operator default implementation from library to allow for easier customization [#303](https://github.com/eclipse-theia/theia-cloud/pull/303)
+- [node] Unify the existing landing and try now pages to a new ViteJS based landing page [#304](https://github.com/eclipse-theia/theia-cloud/pull/304) | [#58](https://github.com/eclipse-theia/theia-cloud-helm/pull/58) - contributed on behalf of STMicroelectronics
   - The new page is based on the old try now page but uses ViteJS instead of the deprecated Create React App
   - Extend configuration options for the new landing page for texts and logo file type
   - Removed terms and conditions
   - Build the common package as ESM and CJS bundles for extended compatibility
-- [common] Add `ingressHostnamePrefixes` list to `AppDefinition.v1beta10` [#298](https://github.com/eclipsesource/theia-cloud/pull/298) | [#57](https://github.com/eclipsesource/theia-cloud-helm/pull/57)
-- [java] Improved naming for kubernetes resources [#326](https://github.com/eclipsesource/theia-cloud/pull/326)
+- [common] Add `ingressHostnamePrefixes` list to `AppDefinition.v1beta10` [#298](https://github.com/eclipse-theia/theia-cloud/pull/298) | [#57](https://github.com/eclipse-theia/theia-cloud-helm/pull/57)
+- [java] Improved naming for kubernetes resources [#326](https://github.com/eclipse-theia/theia-cloud/pull/326)
 
 ### Breaking Changes in 0.11.0
 
-See the helm chart Changelog for [more details](https://github.com/eclipsesource/theia-cloud-helm/blob/main/CHANGELOG.md).
+See the helm chart Changelog for [more details](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md).
 
 ## [0.10.0] - 2024-04-02
 
-- [.github/workflows] Improve version detection in workflows (do not build release commits, auto-detect version for demo publishing) [#280](https://github.com/eclipsesource/theia-cloud/pull/280) - contributed on behalf of STMicroelectronics
-- [node] Separate `monitor` package from other workspaces to fix bundling the extension [#280](https://github.com/eclipsesource/theia-cloud/pull/280) - contributed on behalf of STMicroelectronics
-- [conversion] Provide java conversion webhook for CRD updates [#283](https://github.com/eclipsesource/theia-cloud/pull/283) | [#49](https://github.com/eclipsesource/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
-- [.github/workflows] Add ci for `conversion-webhook` and fix typo to build on version bumps [#283](https://github.com/eclipsesource/theia-cloud/pull/283) | [#49](https://github.com/eclipsesource/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
-- [common] Update CRs, keep previous version and offer Hub (used by conversion-webhook) [#283](https://github.com/eclipsesource/theia-cloud/pull/283) | [#49](https://github.com/eclipsesource/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
+- [.github/workflows] Improve version detection in workflows (do not build release commits, auto-detect version for demo publishing) [#280](https://github.com/eclipse-theia/theia-cloud/pull/280) - contributed on behalf of STMicroelectronics
+- [node] Separate `monitor` package from other workspaces to fix bundling the extension [#280](https://github.com/eclipse-theia/theia-cloud/pull/280) - contributed on behalf of STMicroelectronics
+- [conversion] Provide java conversion webhook for CRD updates [#283](https://github.com/eclipse-theia/theia-cloud/pull/283) | [#49](https://github.com/eclipse-theia/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
+- [.github/workflows] Add ci for `conversion-webhook` and fix typo to build on version bumps [#283](https://github.com/eclipse-theia/theia-cloud/pull/283) | [#49](https://github.com/eclipse-theia/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
+- [common] Update CRs, keep previous version and offer Hub (used by conversion-webhook) [#283](https://github.com/eclipse-theia/theia-cloud/pull/283) | [#49](https://github.com/eclipse-theia/theia-cloud-helm/pull/49) - contributed on behalf of STMicroelectronics
   - Move status like fields to status
     - `Session.v1beta7`: Move `url`, `lastActivity` and `error` fields from the spec to the status.
     - `Workspace.v1beta4`: Move the `error` field from the spec to the status. Also add the `error` field to `Workspace.v1beta3` as it was missing
   - Remove `timeout.strategy` from AppDefinition
     - `AppDefinition.v1beta9`: Removed `timeout.strategy` and `timeout.limit` is now just `timeout`. This was done, as there is only one Strategy left.
-- [java] Update io.fabric8.kubernetes-client to version 6.10.0. Also update Quarkus platform to 3.8.1. This provides kubernetes 1.29 support [#287](https://github.com/eclipsesource/theia-cloud/pull/287)
-- [terraform] Change terraform values to conform to helm chart changes [#289](https://github.com/eclipsesource/theia-cloud/pull/289) | [#52](https://github.com/eclipsesource/theia-cloud-helm/pull/52) - contributed on behalf of STMicroelectronics
+- [java] Update io.fabric8.kubernetes-client to version 6.10.0. Also update Quarkus platform to 3.8.1. This provides kubernetes 1.29 support [#287](https://github.com/eclipse-theia/theia-cloud/pull/287)
+- [terraform] Change terraform values to conform to helm chart changes [#289](https://github.com/eclipse-theia/theia-cloud/pull/289) | [#52](https://github.com/eclipse-theia/theia-cloud-helm/pull/52) - contributed on behalf of STMicroelectronics
 
 ## [0.9.0] - 2024-01-23
 
-- [node/landing-page] Make npm workspace and remove yarn references from repo [#258](https://github.com/eclipsesource/theia-cloud/pull/258) | [#45](https://github.com/eclipsesource/theia-cloud-helm/pull/45) - contributed on behalf of STMicroelectronics
-- [All components] Align [versioning](https://github.com/eclipsesource/theia-cloud#versioning) between all components and introduce Changelog [#258](https://github.com/eclipsesource/theia-cloud/pull/258) | [#45](https://github.com/eclipsesource/theia-cloud-helm/pull/45) - contributed on behalf of STMicroelectronics
-- [All components] Update CRD version scheme for all CRDs from `theia.cloud/vXbeta` to `theia.cloud/v1betaX` [#266](https://github.com/eclipsesource/theia-cloud/pull/266) | [#46](https://github.com/eclipsesource/theia-cloud-helm/pull/46) - contributed on behalf of STMicroelectronics
-- [java/service] Update Quarkus from 2.12.0 to 3.3.1 [#266](https://github.com/eclipsesource/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
-- [java] Update fabric8 Kubernetes client from 5.12.2 to 6.7.2 [#266](https://github.com/eclipsesource/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
-- [java/common] Introduce hub-objects for all custom resources [#266](https://github.com/eclipsesource/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
-- [demo] Fix demo applications to Theia's latest Community Release (1.43.1) [#267](https://github.com/eclipsesource/theia-cloud/pull/267) - contributed on behalf of STMicroelectronics
-- [node/monitor-theia] Make `@theia` dependencies peerDependencies [#267](https://github.com/eclipsesource/theia-cloud/pull/267) - contributed on behalf of STMicroelectronics
-- [node] Update to node 20 [#269](https://github.com/eclipsesource/theia-cloud/pull/269)
-- [All components] Clean up repository [#275](https://github.com/eclipsesource/theia-cloud/pull/275) - contributed on behalf of STMicroelectronics
+- [node/landing-page] Make npm workspace and remove yarn references from repo [#258](https://github.com/eclipse-theia/theia-cloud/pull/258) | [#45](https://github.com/eclipse-theia/theia-cloud-helm/pull/45) - contributed on behalf of STMicroelectronics
+- [All components] Align [versioning](https://github.com/eclipse-theia/theia-cloud#versioning) between all components and introduce Changelog [#258](https://github.com/eclipse-theia/theia-cloud/pull/258) | [#45](https://github.com/eclipse-theia/theia-cloud-helm/pull/45) - contributed on behalf of STMicroelectronics
+- [All components] Update CRD version scheme for all CRDs from `theia.cloud/vXbeta` to `theia.cloud/v1betaX` [#266](https://github.com/eclipse-theia/theia-cloud/pull/266) | [#46](https://github.com/eclipse-theia/theia-cloud-helm/pull/46) - contributed on behalf of STMicroelectronics
+- [java/service] Update Quarkus from 2.12.0 to 3.3.1 [#266](https://github.com/eclipse-theia/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
+- [java] Update fabric8 Kubernetes client from 5.12.2 to 6.7.2 [#266](https://github.com/eclipse-theia/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
+- [java/common] Introduce hub-objects for all custom resources [#266](https://github.com/eclipse-theia/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
+- [demo] Fix demo applications to Theia's latest Community Release (1.43.1) [#267](https://github.com/eclipse-theia/theia-cloud/pull/267) - contributed on behalf of STMicroelectronics
+- [node/monitor-theia] Make `@theia` dependencies peerDependencies [#267](https://github.com/eclipse-theia/theia-cloud/pull/267) - contributed on behalf of STMicroelectronics
+- [node] Update to node 20 [#269](https://github.com/eclipse-theia/theia-cloud/pull/269)
+- [All components] Clean up repository [#275](https://github.com/eclipse-theia/theia-cloud/pull/275) - contributed on behalf of STMicroelectronics
 
 ## [0.8.1] - 2023-10-01
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ For more information, please also visit [our website](https://theia-cloud.io/).
 
 ## Feedback, Help and Support
 
-If you encounter any problems feel free to [open an issue](https://github.com/eclipsesource/theia-cloud/issues/new/choose) on the repo.
-For questions and discussions please use the [the Github discussions](https://github.com/eclipsesource/theia-cloud/discussions).
+If you encounter any problems feel free to [open an issue](https://github.com/eclipse-theia/theia-cloud/issues/new/choose) on the repo.
+For questions and discussions please use the [the Github discussions](https://github.com/eclipse-theia/theia-cloud/discussions).
 You can also reach us via [email](mailto:support@theia-cloud.io?subject=Theia_Cloud).
-In addition, EclipseSource also offers [professional support](https://eclipsesource.com/services/developer-support/) for Theia and Theia Cloud.
+In addition, EclipseSource also offers [professional support](https://eclipse-theia.com/services/developer-support/) for Theia and Theia Cloud.
 
 ## Components
 
@@ -45,7 +45,7 @@ From version 0.9.0 onwards, every component in this repository (and the helm cha
 - **Releases:** Standard releases will occur every three months. We recommend to use these for deployments as those are thoroughly tested and are stable versions. You can then update, after three months, when the next version is available.
 - **Pre-Releases:** Pre-release versions will be released on every commit. These versions will be tagged as `<current-version>-next.<git-sha>`. The latest version of a next version is available at `<current-version>-next`. Pre-releases are ideal for testing the latest features and changes or for making contributions. However we do not recommend, to use those versions in deployments.
 
-The [helm charts](https://github.com/eclipsesource/theia-cloud-helm) are referencing the compatible version in their `appVersion` field.
+The [helm charts](https://github.com/eclipse-theia/theia-cloud-helm) are referencing the compatible version in their `appVersion` field.
 
 Since, npm does not allow tags that follow Semver, next artifacts published to npm have the `next` tag instead of `<currentVersion-next>`.
 This means, that those dependencies will be updated to newer version, once they are available. So again, for deployments you should either pin the version to a specific commit or use the released versions.
@@ -77,7 +77,7 @@ All components are deployed as docker images and may be built with docker. See [
 
 ## Installation
 
-We offer a helm chart at <https://github.com/eclipsesource/theia-cloud-helm> which may be used to install Theia Cloud. Please check our getting started guides below as well, which will explain the possible values in more detail.
+We offer a helm chart at <https://github.com/eclipse-theia/theia-cloud-helm> which may be used to install Theia Cloud. Please check our getting started guides below as well, which will explain the possible values in more detail.
 
 We offer three charts:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ Full disclosure to the general public happens once there is a patch, fix, or wor
 
 Non-committers will be acknowledged for their security research on disclosure if the issue has been reported responsibly.
 
-Publicly disclosed issues are tagged with the [security label](https://github.com/eclipsesource/theia-cloud/labels/security).
+Publicly disclosed issues are tagged with the [security label](https://github.com/eclipse-theia/theia-cloud/labels/security).

--- a/documentation/OpenAPI.md
+++ b/documentation/OpenAPI.md
@@ -30,7 +30,7 @@ docker pull swaggerapi/swagger-ui
 docker run -p 80:8080 swaggerapi/swagger-ui
 ```
 
-Then browse to <http://localhost/> and explore the spec from here: <https://raw.githubusercontent.com/eclipsesource/theia-cloud/main/documentation/openapi.json>
+Then browse to <http://localhost/> and explore the spec from here: <https://raw.githubusercontent.com/eclipse-theia/theia-cloud/main/documentation/openapi.json>
 
 Or explore it from the locally started service: <http://localhost:8081/q/openapi?format=json>.
 

--- a/documentation/platforms/Minikube.md
+++ b/documentation/platforms/Minikube.md
@@ -38,7 +38,7 @@ Build the docker image as usual.
 ### Operator cannot set the workspace URL to the Session
 
 This usually happens when using custom host names that are mapped in a hosts definition file (e.g. `/etc/hosts` on Linux) to the local IP of Minikube.
-One [known case](https://github.com/eclipsesource/theia-cloud/issues/150) occurred on MacOS with Docker Desktop:
+One [known case](https://github.com/eclipse-theia/theia-cloud/issues/150) occurred on MacOS with Docker Desktop:
 The VM running Kubernetes does not know the hosts settings of the host operating system.
 Thus, the custom hostname could not be resolved in the cluster and, thus, the operator could not resolve the session pods' addresses.
 

--- a/java/common/maven-conf/pom.xml
+++ b/java/common/maven-conf/pom.xml
@@ -38,7 +38,7 @@
                 <repository>
                     <id>github</id>
                     <name>GitHub Packages</name>
-                    <url>https://maven.pkg.github.com/eclipsesource/theia-cloud</url>
+                    <url>https://maven.pkg.github.com/eclipse-theia/theia-cloud</url>
                 </repository>
             </distributionManagement>
             <activation>

--- a/node/common/package.json
+++ b/node/common/package.json
@@ -15,9 +15,9 @@
   "homepage": "http://theia-cloud.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eclipsesource/theia-cloud.git"
+    "url": "https://github.com/eclipse-theia/theia-cloud.git"
   },
-  "bugs": "https://github.com/eclipsesource/theia-cloud/issues",
+  "bugs": "https://github.com/eclipse-theia/theia-cloud/issues",
   "contributors": [
     {
       "name": "Theia Cloud Project",

--- a/node/landing-page/src/components/Footer.tsx
+++ b/node/landing-page/src/components/Footer.tsx
@@ -38,7 +38,7 @@ export const Footer = ({appDefinition, appName, additionalApps, setSelectedAppNa
     </p>
     <p>
       Having problems? Please{' '}
-      <a target='_blank' href='https://github.com/eclipsesource/theia-cloud/issues' rel='noreferrer'>
+      <a target='_blank' href='https://github.com/eclipse-theia/theia-cloud/issues' rel='noreferrer'>
         report an issue
       </a>
       .

--- a/node/monitor-theia/package.json
+++ b/node/monitor-theia/package.json
@@ -10,9 +10,9 @@
   "homepage": "http://theia-cloud.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eclipsesource/theia-cloud.git"
+    "url": "https://github.com/eclipse-theia/theia-cloud.git"
   },
-  "bugs": "https://github.com/eclipsesource/theia-cloud/issues",
+  "bugs": "https://github.com/eclipse-theia/theia-cloud/issues",
   "contributors": [
     {
       "name": "Theia Cloud Project",

--- a/node/monitor/package.json
+++ b/node/monitor/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "Theia Cloud"
   },
-  "bugs": "https://github.com/eclipsesource/theia-cloud/issues",
+  "bugs": "https://github.com/eclipse-theia/theia-cloud/issues",
   "contributors": [
     {
       "name": "Theia Cloud Project",
@@ -17,7 +17,7 @@
   "homepage": "http://theia-cloud.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eclipsesource/theia-cloud.git"
+    "url": "https://github.com/eclipse-theia/theia-cloud.git"
   },
   "engines": {
     "vscode": "^1.70.0"


### PR DESCRIPTION
This should fix the maven builds.

See failed runs here:
https://github.com/eclipse-theia/theia-cloud/actions/runs/11125096600
https://github.com/eclipse-theia/theia-cloud/actions/runs/11125096590
https://github.com/eclipse-theia/theia-cloud/actions/runs/11125096563

Also update the eclipsesource urls to eclipse-theia ones, in case the redirects ever stop working.
