### PR TITLE
Improve session pod labels

### DIFF
--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
@@ -1,0 +1,26 @@
+package org.eclipse.theia.cloud.common.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
+import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
+
+public class LabelsUtil {
+    public static final String LABEL_CUSTOM_PREFIX = "theia-cloud.io";
+
+    public static final String LABEL_KEY_SESSION = "app.kubernetes.io/component";
+    public static final String LABEL_VALUE_SESSION = "session";
+
+    public static final String LABEL_KEY_USER = LABEL_CUSTOM_PREFIX + "/user";
+    public static final String LABEL_KEY_APPDEF = LABEL_CUSTOM_PREFIX + "/app-definition";
+
+    public static Map<String, String> createSessionLabels(SessionSpec sessionSpec, AppDefinitionSpec appDefinitionSpec) {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(LABEL_KEY_SESSION, LABEL_VALUE_SESSION);
+        String userName = sessionSpec.getUser().split("@")[0];
+        labels.put(LABEL_KEY_USER, userName);
+        labels.put(LABEL_KEY_APPDEF, appDefinitionSpec.getName());
+        return labels;
+    }
+}

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
@@ -12,14 +12,19 @@ public class LabelsUtil {
     public static final String LABEL_KEY_SESSION = "app.kubernetes.io/component";
     public static final String LABEL_VALUE_SESSION = "session";
 
+    public static final String LABEL_KEY_THEIACLOUD = "app.kubernetes.io/part-of";
+    public static final String LABEL_VALUE_THEIACLOUD = "theia-cloud";
+
     public static final String LABEL_KEY_USER = LABEL_CUSTOM_PREFIX + "/user";
     public static final String LABEL_KEY_APPDEF = LABEL_CUSTOM_PREFIX + "/app-definition";
 
-    public static Map<String, String> createSessionLabels(SessionSpec sessionSpec, AppDefinitionSpec appDefinitionSpec) {
+    public static Map<String, String> createSessionLabels(SessionSpec sessionSpec,
+            AppDefinitionSpec appDefinitionSpec) {
         Map<String, String> labels = new HashMap<>();
         labels.put(LABEL_KEY_SESSION, LABEL_VALUE_SESSION);
-        String userName = sessionSpec.getUser().split("@")[0];
-        labels.put(LABEL_KEY_USER, userName);
+        labels.put(LABEL_KEY_THEIACLOUD, LABEL_VALUE_THEIACLOUD);
+        String sanitizedUser = sessionSpec.getUser().replaceAll("@", "_at_").replaceAll("[^a-zA-Z0-9]", "_");
+        labels.put(LABEL_KEY_USER, sanitizedUser);
         labels.put(LABEL_KEY_APPDEF, appDefinitionSpec.getName());
         return labels;
     }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/appdef/EagerStartAppDefinitionAddedHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/appdef/EagerStartAppDefinitionAddedHandler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -104,10 +105,12 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
         Set<Integer> missingServiceIds = TheiaCloudServiceUtil.computeIdsOfMissingServices(appDefinition, correlationId,
                 instances, existingServices);
 
+        Map<String, String> labelsToAdd = new HashMap<String, String>();
+
         /* Create missing services for this app definition */
         for (int instance : missingServiceIds) {
             createAndApplyService(client.kubernetes(), client.namespace(), correlationId, appDefinitionResourceName,
-                    appDefinitionResourceUID, instance, appDefinition, arguments.isUseKeycloak());
+                    appDefinitionResourceUID, instance, appDefinition, arguments.isUseKeycloak(), labelsToAdd);
         }
 
         if (arguments.isUseKeycloak()) {
@@ -130,11 +133,13 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
             /* Create missing configmaps for this app definition */
             for (int instance : missingProxyIds) {
                 createAndApplyProxyConfigMap(client.kubernetes(), client.namespace(), correlationId,
-                        appDefinitionResourceName, appDefinitionResourceUID, instance, appDefinition);
+                        appDefinitionResourceName, appDefinitionResourceUID, instance, appDefinition,
+                        labelsToAdd);
             }
             for (int instance : missingEmailIds) {
                 createAndApplyEmailConfigMap(client.kubernetes(), client.namespace(), correlationId,
-                        appDefinitionResourceName, appDefinitionResourceUID, instance, appDefinition);
+                        appDefinitionResourceName, appDefinitionResourceUID, instance, appDefinition,
+                        labelsToAdd);
             }
         }
 
@@ -149,14 +154,14 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
         /* Create missing deployments for this app definition */
         for (int instance : missingDeploymentIds) {
             createAndApplyDeployment(client.kubernetes(), client.namespace(), correlationId, appDefinitionResourceName,
-                    appDefinitionResourceUID, instance, appDefinition, arguments.isUseKeycloak());
+                    appDefinitionResourceUID, instance, appDefinition, arguments.isUseKeycloak(), labelsToAdd);
         }
         return true;
     }
 
     protected void createAndApplyService(NamespacedKubernetesClient client, String namespace, String correlationId,
             String appDefinitionResourceName, String appDefinitionResourceUID, int instance,
-            AppDefinition appDefinition, boolean useOAuth2Proxy) {
+            AppDefinition appDefinition, boolean useOAuth2Proxy, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudServiceUtil.getServiceReplacements(namespace, appDefinition,
                 instance);
         String templateYaml = useOAuth2Proxy ? AddedHandlerUtil.TEMPLATE_SERVICE_YAML
@@ -172,12 +177,13 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
             return;
         }
         K8sUtil.loadAndCreateServiceWithOwnerReference(client, namespace, correlationId, serviceYaml, AppDefinition.API,
-                AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0);
+                AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0,
+                labelsToAdd);
     }
 
     protected void createAndApplyDeployment(NamespacedKubernetesClient client, String namespace, String correlationId,
             String appDefinitionResourceName, String appDefinitionResourceUID, int instance,
-            AppDefinition appDefinition, boolean useOAuth2Proxy) {
+            AppDefinition appDefinition, boolean useOAuth2Proxy, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = deploymentReplacements.getReplacements(namespace, appDefinition, instance);
         String templateYaml = useOAuth2Proxy ? AddedHandlerUtil.TEMPLATE_DEPLOYMENT_YAML
                 : AddedHandlerUtil.TEMPLATE_DEPLOYMENT_WITHOUT_AOUTH2_PROXY_YAML;
@@ -193,6 +199,7 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
         }
         K8sUtil.loadAndCreateDeploymentWithOwnerReference(client, namespace, correlationId, deploymentYaml,
                 AppDefinition.API, AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0,
+                labelsToAdd,
                 deployment -> {
                     bandwidthLimiter.limit(deployment, appDefinition.getSpec().getDownlinkLimit(),
                             appDefinition.getSpec().getUplinkLimit(), correlationId);
@@ -206,7 +213,7 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
 
     protected void createAndApplyProxyConfigMap(NamespacedKubernetesClient client, String namespace,
             String correlationId, String appDefinitionResourceName, String appDefinitionResourceUID, int instance,
-            AppDefinition appDefinition) {
+            AppDefinition appDefinition, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudConfigMapUtil.getProxyConfigMapReplacements(namespace,
                 appDefinition, instance);
         String configMapYaml;
@@ -221,6 +228,7 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
         }
         K8sUtil.loadAndCreateConfigMapWithOwnerReference(client, namespace, correlationId, configMapYaml,
                 AppDefinition.API, AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0,
+                labelsToAdd,
                 configMap -> {
                     String host = arguments.getInstancesHost() + ingressPathProvider.getPath(appDefinition, instance);
                     int port = appDefinition.getSpec().getPort();
@@ -230,7 +238,7 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
 
     protected void createAndApplyEmailConfigMap(NamespacedKubernetesClient client, String namespace,
             String correlationId, String appDefinitionResourceName, String appDefinitionResourceUID, int instance,
-            AppDefinition appDefinition) {
+            AppDefinition appDefinition, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudConfigMapUtil.getEmailConfigMapReplacements(namespace,
                 appDefinition, instance);
         String configMapYaml;
@@ -244,7 +252,8 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
             return;
         }
         K8sUtil.loadAndCreateConfigMapWithOwnerReference(client, namespace, correlationId, configMapYaml,
-                AppDefinition.API, AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0);
+                AppDefinition.API, AppDefinition.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0,
+                labelsToAdd);
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerStartSessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerStartSessionHandler.java
@@ -121,7 +121,7 @@ public class EagerStartSessionHandler implements SessionHandler {
         try {
             client.services().inNamespace(client.namespace()).withName(serviceToUse.get().getMetadata().getName())
                 .edit(service -> {
-                    LOGGER.info("Setting pod labels");
+                    LOGGER.debug("Setting session labels");
                     Map<String, String> labels = service.getMetadata().getLabels();
                     if (labels == null) {
                         labels = new HashMap<>();

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
@@ -157,6 +157,10 @@ public class LazySessionHandler implements SessionHandler {
             return false;
         }
         AppDefinition appDefinition = optionalAppDefinition.get();
+        AppDefinitionSpec appDefinitionSpec = appDefinition.getSpec();
+
+        /* label maps */
+        Map<String, String> labelsToAdd = LabelsUtil.createSessionLabels(session.getSpec(), appDefinitionSpec);
 
         if (hasMaxInstancesReached(appDefinition, session, correlationId)) {
             client.sessions().updateStatus(correlationId, session, s -> {
@@ -202,7 +206,7 @@ public class LazySessionHandler implements SessionHandler {
         }
 
         Optional<Service> serviceToUse = createAndApplyService(correlationId, sessionResourceName, sessionResourceUID,
-                session, appDefinition.getSpec(), arguments.isUseKeycloak());
+                session, appDefinitionSpec, arguments.isUseKeycloak(), labelsToAdd);
         if (serviceToUse.isEmpty()) {
             LOGGER.error(formatLogMessage(correlationId, "Unable to create service for session " + sessionSpec));
             client.sessions().updateStatus(correlationId, session, s -> {
@@ -228,9 +232,9 @@ public class LazySessionHandler implements SessionHandler {
                 // this handler
                 return true;
             }
-            createAndApplyEmailConfigMap(correlationId, sessionResourceName, sessionResourceUID, session);
+            createAndApplyEmailConfigMap(correlationId, sessionResourceName, sessionResourceUID, session, labelsToAdd);
             createAndApplyProxyConfigMap(correlationId, sessionResourceName, sessionResourceUID, session,
-                    appDefinition);
+                    appDefinition, labelsToAdd);
         }
 
         /* Create deployment for this session */
@@ -249,7 +253,7 @@ public class LazySessionHandler implements SessionHandler {
 
         Optional<String> storageName = getStorageName(session, correlationId);
         createAndApplyDeployment(correlationId, sessionResourceName, sessionResourceUID, session, appDefinition,
-                storageName, arguments.isUseKeycloak());
+                storageName, arguments.isUseKeycloak(), labelsToAdd);
 
         /* adjust the ingress */
         String host;
@@ -373,7 +377,8 @@ public class LazySessionHandler implements SessionHandler {
     }
 
     protected Optional<Service> createAndApplyService(String correlationId, String sessionResourceName,
-            String sessionResourceUID, Session session, AppDefinitionSpec appDefinitionSpec, boolean useOAuth2Proxy) {
+            String sessionResourceUID, Session session, AppDefinitionSpec appDefinitionSpec, boolean useOAuth2Proxy,
+            Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudServiceUtil.getServiceReplacements(client.namespace(), session,
                 appDefinitionSpec);
         String templateYaml = useOAuth2Proxy ? AddedHandlerUtil.TEMPLATE_SERVICE_YAML
@@ -387,11 +392,11 @@ public class LazySessionHandler implements SessionHandler {
             return Optional.empty();
         }
         return K8sUtil.loadAndCreateServiceWithOwnerReference(client.kubernetes(), client.namespace(), correlationId,
-                serviceYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0);
+                serviceYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0, labelsToAdd);
     }
 
     protected void createAndApplyEmailConfigMap(String correlationId, String sessionResourceName,
-            String sessionResourceUID, Session session) {
+            String sessionResourceUID, Session session, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudConfigMapUtil.getEmailConfigMapReplacements(client.namespace(),
                 session);
         String configMapYaml;
@@ -403,14 +408,15 @@ public class LazySessionHandler implements SessionHandler {
             return;
         }
         K8sUtil.loadAndCreateConfigMapWithOwnerReference(client.kubernetes(), client.namespace(), correlationId,
-                configMapYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0, configmap -> {
+                configMapYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0,
+                labelsToAdd, configmap -> {
                     configmap.setData(Collections.singletonMap(AddedHandlerUtil.FILENAME_AUTHENTICATED_EMAILS_LIST,
                             session.getSpec().getUser()));
                 });
     }
 
     protected void createAndApplyProxyConfigMap(String correlationId, String sessionResourceName,
-            String sessionResourceUID, Session session, AppDefinition appDefinition) {
+            String sessionResourceUID, Session session, AppDefinition appDefinition, Map<String, String> labelsToAdd) {
         Map<String, String> replacements = TheiaCloudConfigMapUtil.getProxyConfigMapReplacements(client.namespace(),
                 session);
         String configMapYaml;
@@ -422,7 +428,8 @@ public class LazySessionHandler implements SessionHandler {
             return;
         }
         K8sUtil.loadAndCreateConfigMapWithOwnerReference(client.kubernetes(), client.namespace(), correlationId,
-                configMapYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0, configMap -> {
+                configMapYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0,
+                labelsToAdd, configMap -> {
                     String host = arguments.getInstancesHost() + ingressPathProvider.getPath(appDefinition, session);
                     int port = appDefinition.getSpec().getPort();
                     AddedHandlerUtil.updateProxyConfigMap(client.kubernetes(), client.namespace(), configMap, host,
@@ -431,7 +438,8 @@ public class LazySessionHandler implements SessionHandler {
     }
 
     protected void createAndApplyDeployment(String correlationId, String sessionResourceName, String sessionResourceUID,
-            Session session, AppDefinition appDefinition, Optional<String> pvName, boolean useOAuth2Proxy) {
+            Session session, AppDefinition appDefinition, Optional<String> pvName, boolean useOAuth2Proxy,
+            Map<String, String> labelsToAdd) {
         Map<String, String> replacements = deploymentReplacements.getReplacements(client.namespace(), appDefinition,
                 session);
         String templateYaml = useOAuth2Proxy ? AddedHandlerUtil.TEMPLATE_DEPLOYMENT_YAML
@@ -445,16 +453,16 @@ public class LazySessionHandler implements SessionHandler {
             return;
         }
         K8sUtil.loadAndCreateDeploymentWithOwnerReference(client.kubernetes(), client.namespace(), correlationId,
-                deploymentYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0, deployment -> {
+                deploymentYaml, Session.API, Session.KIND, sessionResourceName, sessionResourceUID, 0,
+                labelsToAdd, deployment -> {
 
-                    LOGGER.info("Setting pod labels");
+                    LOGGER.debug("Setting session labels");
                     Map<String, String> labels = deployment.getSpec().getTemplate().getMetadata().getLabels();
                     if (labels == null) {
                         labels = new HashMap<>();
                         deployment.getSpec().getTemplate().getMetadata().setLabels(labels);
                     }
-                    Map<String, String> newLabels = LabelsUtil.createSessionLabels(session.getSpec(), appDefinition.getSpec());
-                    labels.putAll(newLabels);
+                    labels.putAll(labelsToAdd);
 
                     pvName.ifPresent(name -> addVolumeClaim(deployment, name, appDefinition.getSpec()));
                     bandwidthLimiter.limit(deployment, appDefinition.getSpec().getDownlinkLimit(),

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/K8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/K8sUtil.java
@@ -177,8 +177,7 @@ public final class K8sUtil {
             newItem.getMetadata().getLabels().putAll(labelsToAdd);
 
             // If the resource is a Deployment, also apply labels to the pod template metadata
-            if (newItem instanceof Deployment) {
-                Deployment deployment = (Deployment) newItem;
+            if (newItem instanceof Deployment deployment) {
                 if (deployment.getSpec().getTemplate().getMetadata().getLabels() == null) {
                     deployment.getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
                 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/K8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/K8sUtil.java
@@ -21,6 +21,8 @@ import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessag
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -110,50 +112,54 @@ public final class K8sUtil {
 
     public static Optional<Ingress> loadAndCreateIngressWithOwnerReference(NamespacedKubernetesClient client,
             String namespace, String correlationId, String yaml, String ownerAPIVersion, String ownerKind,
-            String ownerName, String ownerUid, int ownerReferenceIndex) {
+            String ownerName, String ownerUid, int ownerReferenceIndex, Map<String, String> labelsToAdd) {
         return loadAndCreateTypeWithOwnerReference(client, namespace, correlationId, yaml, ownerAPIVersion, ownerKind,
                 ownerName, ownerUid, ownerReferenceIndex, INGRESS,
-                client.network().v1().ingresses().inNamespace(namespace), item -> {
+                client.network().v1().ingresses().inNamespace(namespace), labelsToAdd, item -> {
                 });
     }
 
     public static Optional<Service> loadAndCreateServiceWithOwnerReference(NamespacedKubernetesClient client,
             String namespace, String correlationId, String yaml, String ownerAPIVersion, String ownerKind,
-            String ownerName, String ownerUid, int ownerReferenceIndex) {
+            String ownerName, String ownerUid, int ownerReferenceIndex, Map<String, String> labelsToAdd) {
         return loadAndCreateTypeWithOwnerReference(client, namespace, correlationId, yaml, ownerAPIVersion, ownerKind,
-                ownerName, ownerUid, ownerReferenceIndex, SERVICE, client.services().inNamespace(namespace), item -> {
+                ownerName, ownerUid, ownerReferenceIndex, SERVICE, client.services().inNamespace(namespace),
+                labelsToAdd, item -> {
                 });
     }
 
     public static Optional<ConfigMap> loadAndCreateConfigMapWithOwnerReference(NamespacedKubernetesClient client,
             String namespace, String correlationId, String yaml, String ownerAPIVersion, String ownerKind,
-            String ownerName, String ownerUid, int ownerReferenceIndex) {
+            String ownerName, String ownerUid, int ownerReferenceIndex, Map<String, String> labelsToAdd) {
         return loadAndCreateTypeWithOwnerReference(client, namespace, correlationId, yaml, ownerAPIVersion, ownerKind,
                 ownerName, ownerUid, ownerReferenceIndex, CONFIG_MAP, client.configMaps().inNamespace(namespace),
-                item -> {
+                labelsToAdd, item -> {
                 });
     }
 
     public static Optional<Deployment> loadAndCreateDeploymentWithOwnerReference(NamespacedKubernetesClient client,
             String namespace, String correlationId, String yaml, String ownerAPIVersion, String ownerKind,
-            String ownerName, String ownerUid, int ownerReferenceIndex, Consumer<Deployment> additionalModification) {
+            String ownerName, String ownerUid, int ownerReferenceIndex, Map<String, String> labelsToAdd,
+            Consumer<Deployment> additionalModification) {
         return loadAndCreateTypeWithOwnerReference(client, namespace, correlationId, yaml, ownerAPIVersion, ownerKind,
                 ownerName, ownerUid, ownerReferenceIndex, DEPLOYMENT,
-                client.apps().deployments().inNamespace(namespace), additionalModification);
+                client.apps().deployments().inNamespace(namespace), labelsToAdd, additionalModification);
     }
 
     public static Optional<ConfigMap> loadAndCreateConfigMapWithOwnerReference(NamespacedKubernetesClient client,
             String namespace, String correlationId, String yaml, String ownerAPIVersion, String ownerKind,
-            String ownerName, String ownerUid, int ownerReferenceIndex, Consumer<ConfigMap> additionalModification) {
+            String ownerName, String ownerUid, int ownerReferenceIndex, Map<String, String> labelsToAdd,
+            Consumer<ConfigMap> additionalModification) {
         return loadAndCreateTypeWithOwnerReference(client, namespace, correlationId, yaml, ownerAPIVersion, ownerKind,
                 ownerName, ownerUid, ownerReferenceIndex, CONFIG_MAP, client.configMaps().inNamespace(namespace),
-                additionalModification);
+                labelsToAdd, additionalModification);
     }
 
     private static <T extends HasMetadata, U, V extends Resource<T>> Optional<T> loadAndCreateTypeWithOwnerReference(
             NamespacedKubernetesClient client, String namespace, String correlationId, String yaml,
             String ownerAPIVersion, String ownerKind, String ownerName, String ownerUid, int ownerReferenceIndex,
-            String typeName, NonNamespaceOperation<T, U, V> items, Consumer<T> additionalModification) {
+            String typeName, NonNamespaceOperation<T, U, V> items, Map<String, String> labelsToAdd,
+            Consumer<T> additionalModification) {
 
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(yaml.getBytes())) {
 
@@ -162,6 +168,21 @@ public final class K8sUtil {
             if (newItem == null) {
                 LOGGER.error(formatLogMessage(correlationId, "Loading new " + typeName + " resulted in null object"));
                 return Optional.empty();
+            }
+
+            // Apply labels to the resource metadata
+            if (newItem.getMetadata().getLabels() == null) {
+                newItem.getMetadata().setLabels(new HashMap<>());
+            }
+            newItem.getMetadata().getLabels().putAll(labelsToAdd);
+
+            // If the resource is a Deployment, also apply labels to the pod template metadata
+            if (newItem instanceof Deployment) {
+                Deployment deployment = (Deployment) newItem;
+                if (deployment.getSpec().getTemplate().getMetadata().getLabels() == null) {
+                    deployment.getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
+                }
+                deployment.getSpec().getTemplate().getMetadata().getLabels().putAll(labelsToAdd);
             }
 
             ResourceEdit.<T> updateOwnerReference(ownerReferenceIndex, ownerAPIVersion, ownerKind, ownerName, ownerUid,


### PR DESCRIPTION
org.eclipse.theia.cloud.common.util.LabelsUtil is added to encapsulate creation of labels.

To indicate that a pod is a user session, its
'app.kubernetes.io/component' label is set to 'session'.

For custom labels, we use the prefix 'theia-cloud.io'.

This is currently used for:
- Identifying a session pods associated with a user: 'theia-cloud.io/user' = '$username'
- Identifying a session pod by appdefinition name: 'theia-cloud.io/app-definition' = $appdefinitionname

#366