### PR TITLE
Add REST API markdown docs based on openapi definition

### DIFF
--- a/documentation/OpenAPI.md
+++ b/documentation/OpenAPI.md
@@ -50,3 +50,24 @@ Use the `openapi-generator-cli` from the root of this repository:
 ```bash
 openapi-generator-cli generate -g typescript-axios -i ./documentation/openapi.json -o node/common/src/client/ --additional-properties=supportsES6=true,typescriptThreePlus=true --skip-validate-spec
 ```
+
+## Generate API Documentation
+
+Documentation for the service API can be generated as markdown files.
+
+If not already done for generating the typescript API, install the `openapi-generator-cli`:
+
+```bash
+npm install @openapitools/openapi-generator-cli -g
+openapi-generator-cli version-manager set 7.8.0
+```
+
+Use the `openapi-generator-cli` from the root of this repository:
+
+```bash
+openapi-generator-cli generate -g markdown -i ./documentation/openapi.json -o ./documentation/api --skip-validate-spec
+```
+
+> [!TIP]
+> The Open API generator supports generating code and documentation in various languages.
+> Execute `openapi-generator-cli list` to see all of them.

--- a/documentation/api/Apis/AppDefinitionResourceApi.md
+++ b/documentation/api/Apis/AppDefinitionResourceApi.md
@@ -1,0 +1,36 @@
+# AppDefinitionResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceAppdefinitionAppIdGet**](AppDefinitionResourceApi.md#serviceAppdefinitionAppIdGet) | **GET** /service/appdefinition/{appId} | List app definitions |
+
+
+<a name="serviceAppdefinitionAppIdGet"></a>
+# **serviceAppdefinitionAppIdGet**
+> List serviceAppdefinitionAppIdGet(appId)
+
+List app definitions
+
+    List available app definitions.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+
+### Return type
+
+[**List**](../Models/AppDefinitionSpec.md)
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+

--- a/documentation/api/Apis/RootResourceApi.md
+++ b/documentation/api/Apis/RootResourceApi.md
@@ -1,0 +1,64 @@
+# RootResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceAppIdGet**](RootResourceApi.md#serviceAppIdGet) | **GET** /service/{appId} | Ping |
+| [**servicePost**](RootResourceApi.md#servicePost) | **POST** /service | Launch Session |
+
+
+<a name="serviceAppIdGet"></a>
+# **serviceAppIdGet**
+> Boolean serviceAppIdGet(appId)
+
+Ping
+
+    Replies if the service is available.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+
+### Return type
+
+**Boolean**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+<a name="servicePost"></a>
+# **servicePost**
+> String servicePost(LaunchRequest)
+
+Launch Session
+
+    Launches a session and creates a workspace if required. Responds with the URL of the launched session.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **LaunchRequest** | [**LaunchRequest**](../Models/LaunchRequest.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+

--- a/documentation/api/Apis/SessionResourceApi.md
+++ b/documentation/api/Apis/SessionResourceApi.md
@@ -1,0 +1,150 @@
+# SessionResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceSessionAppIdUserGet**](SessionResourceApi.md#serviceSessionAppIdUserGet) | **GET** /service/session/{appId}/{user} | List sessions |
+| [**serviceSessionDelete**](SessionResourceApi.md#serviceSessionDelete) | **DELETE** /service/session | Stop session |
+| [**serviceSessionPatch**](SessionResourceApi.md#serviceSessionPatch) | **PATCH** /service/session | Report session activity |
+| [**serviceSessionPerformanceAppIdSessionNameGet**](SessionResourceApi.md#serviceSessionPerformanceAppIdSessionNameGet) | **GET** /service/session/performance/{appId}/{sessionName} | Get performance metrics |
+| [**serviceSessionPost**](SessionResourceApi.md#serviceSessionPost) | **POST** /service/session | Start a new session |
+
+
+<a name="serviceSessionAppIdUserGet"></a>
+# **serviceSessionAppIdUserGet**
+> List serviceSessionAppIdUserGet(appId, user)
+
+List sessions
+
+    List sessions of a user.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+| **user** | **String**|  | [default to null] |
+
+### Return type
+
+[**List**](../Models/SessionSpec.md)
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="serviceSessionDelete"></a>
+# **serviceSessionDelete**
+> Boolean serviceSessionDelete(SessionStopRequest)
+
+Stop session
+
+    Stops a session.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **SessionStopRequest** | [**SessionStopRequest**](../Models/SessionStopRequest.md)|  | [optional] |
+
+### Return type
+
+**Boolean**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+<a name="serviceSessionPatch"></a>
+# **serviceSessionPatch**
+> Boolean serviceSessionPatch(SessionActivityRequest)
+
+Report session activity
+
+    Updates the last activity timestamp for a session to monitor activity.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **SessionActivityRequest** | [**SessionActivityRequest**](../Models/SessionActivityRequest.md)|  | [optional] |
+
+### Return type
+
+**Boolean**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+<a name="serviceSessionPerformanceAppIdSessionNameGet"></a>
+# **serviceSessionPerformanceAppIdSessionNameGet**
+> SessionPerformance serviceSessionPerformanceAppIdSessionNameGet(appId, sessionName)
+
+Get performance metrics
+
+    Returns the current CPU and memory usage of the session&#39;s pod.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+| **sessionName** | **String**|  | [default to null] |
+
+### Return type
+
+[**SessionPerformance**](../Models/SessionPerformance.md)
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="serviceSessionPost"></a>
+# **serviceSessionPost**
+> String serviceSessionPost(SessionStartRequest)
+
+Start a new session
+
+    Starts a new session for an existing workspace and responds with the URL of the started session.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **SessionStartRequest** | [**SessionStartRequest**](../Models/SessionStartRequest.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+

--- a/documentation/api/Apis/WorkspaceResourceApi.md
+++ b/documentation/api/Apis/WorkspaceResourceApi.md
@@ -1,0 +1,93 @@
+# WorkspaceResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceWorkspaceAppIdUserGet**](WorkspaceResourceApi.md#serviceWorkspaceAppIdUserGet) | **GET** /service/workspace/{appId}/{user} | List workspaces |
+| [**serviceWorkspaceDelete**](WorkspaceResourceApi.md#serviceWorkspaceDelete) | **DELETE** /service/workspace | Delete workspace |
+| [**serviceWorkspacePost**](WorkspaceResourceApi.md#serviceWorkspacePost) | **POST** /service/workspace | Create workspace |
+
+
+<a name="serviceWorkspaceAppIdUserGet"></a>
+# **serviceWorkspaceAppIdUserGet**
+> List serviceWorkspaceAppIdUserGet(appId, user)
+
+List workspaces
+
+    Lists the workspaces of a user.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+| **user** | **String**|  | [default to null] |
+
+### Return type
+
+[**List**](../Models/UserWorkspace.md)
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="serviceWorkspaceDelete"></a>
+# **serviceWorkspaceDelete**
+> Boolean serviceWorkspaceDelete(WorkspaceDeletionRequest)
+
+Delete workspace
+
+    Deletes a workspace.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **WorkspaceDeletionRequest** | [**WorkspaceDeletionRequest**](../Models/WorkspaceDeletionRequest.md)|  | [optional] |
+
+### Return type
+
+**Boolean**
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+<a name="serviceWorkspacePost"></a>
+# **serviceWorkspacePost**
+> UserWorkspace serviceWorkspacePost(WorkspaceCreationRequest)
+
+Create workspace
+
+    Creates a new workspace for a user.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **WorkspaceCreationRequest** | [**WorkspaceCreationRequest**](../Models/WorkspaceCreationRequest.md)|  | [optional] |
+
+### Return type
+
+[**UserWorkspace**](../Models/UserWorkspace.md)
+
+### Authorization
+
+[SecurityScheme](../README.md#SecurityScheme)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/documentation/api/Models/ActivityTracker.md
+++ b/documentation/api/Models/ActivityTracker.md
@@ -1,0 +1,10 @@
+# ActivityTracker
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **timeoutAfter** | **Integer** |  | [optional] [default to null] |
+| **notifyAfter** | **Integer** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/AppDefinitionListRequest.md
+++ b/documentation/api/Models/AppDefinitionListRequest.md
@@ -1,0 +1,9 @@
+# AppDefinitionListRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/AppDefinitionSpec.md
+++ b/documentation/api/Models/AppDefinitionSpec.md
@@ -1,0 +1,28 @@
+# AppDefinitionSpec
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **name** | **String** |  | [optional] [default to null] |
+| **image** | **String** |  | [optional] [default to null] |
+| **imagePullPolicy** | **String** |  | [optional] [default to null] |
+| **pullSecret** | **String** |  | [optional] [default to null] |
+| **uid** | **Integer** |  | [optional] [default to null] |
+| **port** | **Integer** |  | [optional] [default to null] |
+| **ingressname** | **String** |  | [optional] [default to null] |
+| **minInstances** | **Integer** |  | [optional] [default to null] |
+| **maxInstances** | **Integer** |  | [optional] [default to null] |
+| **timeout** | **Integer** |  | [optional] [default to null] |
+| **requestsMemory** | **String** |  | [optional] [default to null] |
+| **requestsCpu** | **String** |  | [optional] [default to null] |
+| **limitsMemory** | **String** |  | [optional] [default to null] |
+| **limitsCpu** | **String** |  | [optional] [default to null] |
+| **downlinkLimit** | **Integer** |  | [optional] [default to null] |
+| **uplinkLimit** | **Integer** |  | [optional] [default to null] |
+| **mountPath** | **String** |  | [optional] [default to null] |
+| **monitor** | [**Monitor**](Monitor.md) |  | [optional] [default to null] |
+| **options** | **Map** |  | [optional] [default to null] |
+| **ingressHostnamePrefixes** | **List** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/EnvironmentVars.md
+++ b/documentation/api/Models/EnvironmentVars.md
@@ -1,0 +1,11 @@
+# EnvironmentVars
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **fromMap** | **Map** | Map of environment variables to be passed to Deployment.  Ignored if Theia applications are started eagerly.  Empty by default. | [optional] [default to null] |
+| **fromConfigMaps** | **List** | List of ConfigMaps (by name) containing environment variables to be passed to Deployment as envFrom.configMapRef.  Ignored if Theia applications are started eagerly.  Empty by default. | [optional] [default to null] |
+| **fromSecrets** | **List** | List of Secrets (by name) containing environment variables to be passed to Deployment as envFrom.secretRef.  Ignored if Theia applications are started eagerly.  Empty by default. | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/LaunchRequest.md
+++ b/documentation/api/Models/LaunchRequest.md
@@ -1,0 +1,16 @@
+# LaunchRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **appDefinition** | **String** | The app to launch. Needs to be set if a new or ephemeral session should be launched. For an existing workspace the last app definition will be used if none is given. | [optional] [default to null] |
+| **workspaceName** | **String** | The name of the workspace to mount/create. Needs to be set if an existing workspace should be launched. | [optional] [default to null] |
+| **label** | **String** | The label of the workspace to mount/create. If no label is given, a default label will be generated. | [optional] [default to null] |
+| **ephemeral** | **Boolean** | If true no workspace will be created for the session. | [optional] [default to null] |
+| **timeout** | **Integer** | Number of minutes to wait for session launch. Default is 3 Minutes. | [optional] [default to null] |
+| **env** | [**EnvironmentVars**](EnvironmentVars.md) | Environment variables | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/Monitor.md
+++ b/documentation/api/Models/Monitor.md
@@ -1,0 +1,10 @@
+# Monitor
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **port** | **Integer** |  | [optional] [default to null] |
+| **activityTracker** | [**ActivityTracker**](ActivityTracker.md) |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/PingRequest.md
+++ b/documentation/api/Models/PingRequest.md
@@ -1,0 +1,9 @@
+# PingRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionActivityRequest.md
+++ b/documentation/api/Models/SessionActivityRequest.md
@@ -1,0 +1,10 @@
+# SessionActivityRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **sessionName** | **String** | The name of the session for which activity is reported. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionListRequest.md
+++ b/documentation/api/Models/SessionListRequest.md
@@ -1,0 +1,10 @@
+# SessionListRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionPerformance.md
+++ b/documentation/api/Models/SessionPerformance.md
@@ -1,0 +1,12 @@
+# SessionPerformance
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **cpuAmount** | **String** | Used CPU amount of the workspace | [default to null] |
+| **cpuFormat** | **String** | Used CPU format of the workspace | [default to null] |
+| **memoryAmount** | **String** | Used memory amount of the workspace | [default to null] |
+| **memoryFormat** | **String** | Used memory format of the workspace | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionPerformanceRequest.md
+++ b/documentation/api/Models/SessionPerformanceRequest.md
@@ -1,0 +1,10 @@
+# SessionPerformanceRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **sessionName** | **String** | The name of the session | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionSpec.md
+++ b/documentation/api/Models/SessionSpec.md
@@ -1,0 +1,17 @@
+# SessionSpec
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **name** | **String** |  | [optional] [default to null] |
+| **appDefinition** | **String** |  | [optional] [default to null] |
+| **user** | **String** |  | [optional] [default to null] |
+| **workspace** | **String** |  | [optional] [default to null] |
+| **sessionSecret** | **String** |  | [optional] [default to null] |
+| **options** | **Map** |  | [optional] [default to null] |
+| **envVars** | **Map** |  | [optional] [default to null] |
+| **envVarsFromConfigMaps** | **List** |  | [optional] [default to null] |
+| **envVarsFromSecrets** | **List** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionStartRequest.md
+++ b/documentation/api/Models/SessionStartRequest.md
@@ -1,0 +1,14 @@
+# SessionStartRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **appDefinition** | **String** | The app to launch. | [default to null] |
+| **workspaceName** | **String** | The name of the workspace to mount/create. | [optional] [default to null] |
+| **timeout** | **Integer** | Number of minutes to wait for session launch. Default is 3 Minutes. | [optional] [default to null] |
+| **env** | [**EnvironmentVars**](EnvironmentVars.md) | Environment variables | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/SessionStopRequest.md
+++ b/documentation/api/Models/SessionStopRequest.md
@@ -1,0 +1,11 @@
+# SessionStopRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **sessionName** | **String** | The name of the session to stop. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/UserWorkspace.md
+++ b/documentation/api/Models/UserWorkspace.md
@@ -1,0 +1,13 @@
+# UserWorkspace
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **name** | **String** | The name of the workspace | [default to null] |
+| **label** | **String** | The label of the workspace | [default to null] |
+| **appDefinition** | **String** | The app this workspace was used with. | [optional] [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **active** | **Boolean** | Whether the workspace is in use at the moment. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/WorkspaceCreationRequest.md
+++ b/documentation/api/Models/WorkspaceCreationRequest.md
@@ -1,0 +1,12 @@
+# WorkspaceCreationRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **appDefinition** | **String** | The app this workspace will be used with. | [optional] [default to null] |
+| **label** | **String** | The label of the workspace | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/WorkspaceDeletionRequest.md
+++ b/documentation/api/Models/WorkspaceDeletionRequest.md
@@ -1,0 +1,11 @@
+# WorkspaceDeletionRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+| **workspaceName** | **String** | The name of the workspace to delete. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/WorkspaceListRequest.md
+++ b/documentation/api/Models/WorkspaceListRequest.md
@@ -1,0 +1,10 @@
+# WorkspaceListRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **user** | **String** | The user identification, usually the email address. | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/README.md
+++ b/documentation/api/README.md
@@ -1,0 +1,56 @@
+# Documentation for Theia Cloud API
+
+<a name="documentation-for-api-endpoints"></a>
+## Documentation for API Endpoints
+
+All URIs are relative to *http://localhost*
+
+| Class | Method | HTTP request | Description |
+|------------ | ------------- | ------------- | -------------|
+| *AppDefinitionResourceApi* | [**serviceAppdefinitionAppIdGet**](Apis/AppDefinitionResourceApi.md#serviceappdefinitionappidget) | **GET** /service/appdefinition/{appId} | List app definitions |
+| *RootResourceApi* | [**serviceAppIdGet**](Apis/RootResourceApi.md#serviceappidget) | **GET** /service/{appId} | Ping |
+*RootResourceApi* | [**servicePost**](Apis/RootResourceApi.md#servicepost) | **POST** /service | Launch Session |
+| *SessionResourceApi* | [**serviceSessionAppIdUserGet**](Apis/SessionResourceApi.md#servicesessionappiduserget) | **GET** /service/session/{appId}/{user} | List sessions |
+*SessionResourceApi* | [**serviceSessionDelete**](Apis/SessionResourceApi.md#servicesessiondelete) | **DELETE** /service/session | Stop session |
+*SessionResourceApi* | [**serviceSessionPatch**](Apis/SessionResourceApi.md#servicesessionpatch) | **PATCH** /service/session | Report session activity |
+*SessionResourceApi* | [**serviceSessionPerformanceAppIdSessionNameGet**](Apis/SessionResourceApi.md#servicesessionperformanceappidsessionnameget) | **GET** /service/session/performance/{appId}/{sessionName} | Get performance metrics |
+*SessionResourceApi* | [**serviceSessionPost**](Apis/SessionResourceApi.md#servicesessionpost) | **POST** /service/session | Start a new session |
+| *WorkspaceResourceApi* | [**serviceWorkspaceAppIdUserGet**](Apis/WorkspaceResourceApi.md#serviceworkspaceappiduserget) | **GET** /service/workspace/{appId}/{user} | List workspaces |
+*WorkspaceResourceApi* | [**serviceWorkspaceDelete**](Apis/WorkspaceResourceApi.md#serviceworkspacedelete) | **DELETE** /service/workspace | Delete workspace |
+*WorkspaceResourceApi* | [**serviceWorkspacePost**](Apis/WorkspaceResourceApi.md#serviceworkspacepost) | **POST** /service/workspace | Create workspace |
+
+
+<a name="documentation-for-models"></a>
+## Documentation for Models
+
+ - [ActivityTracker](./Models/ActivityTracker.md)
+ - [AppDefinitionListRequest](./Models/AppDefinitionListRequest.md)
+ - [AppDefinitionSpec](./Models/AppDefinitionSpec.md)
+ - [EnvironmentVars](./Models/EnvironmentVars.md)
+ - [LaunchRequest](./Models/LaunchRequest.md)
+ - [Monitor](./Models/Monitor.md)
+ - [PingRequest](./Models/PingRequest.md)
+ - [SessionActivityRequest](./Models/SessionActivityRequest.md)
+ - [SessionListRequest](./Models/SessionListRequest.md)
+ - [SessionPerformance](./Models/SessionPerformance.md)
+ - [SessionPerformanceRequest](./Models/SessionPerformanceRequest.md)
+ - [SessionSpec](./Models/SessionSpec.md)
+ - [SessionStartRequest](./Models/SessionStartRequest.md)
+ - [SessionStopRequest](./Models/SessionStopRequest.md)
+ - [UserWorkspace](./Models/UserWorkspace.md)
+ - [WorkspaceCreationRequest](./Models/WorkspaceCreationRequest.md)
+ - [WorkspaceDeletionRequest](./Models/WorkspaceDeletionRequest.md)
+ - [WorkspaceListRequest](./Models/WorkspaceListRequest.md)
+
+
+<a name="documentation-for-authorization"></a>
+## Documentation for Authorization
+
+<a name="SecurityScheme"></a>
+### SecurityScheme
+
+- **Type**: OAuth
+- **Flow**: implicit
+- **Authorization URL**: 
+- **Scopes**: N/A
+


### PR DESCRIPTION
Use the openapi-generator-cli to generate markdown docs from the openapi.json.
Also document how this works and add a hint that the generator supports
various doc and code languages.