### PR TITLE
Fix and Improve Eager Start Handling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -150,6 +150,47 @@
       "preLaunchTask": "Build and Install Operator library"
     },
     {
+      // This works with terraform config 2-04_try-now_paths_eager_start
+      "type": "java",
+      "name": "Debug Operator (eager start try-now-paths)",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/java/operator/org.eclipse.theia.cloud.defaultoperator",
+      "mainClass": "org.eclipse.theia.cloud.defaultoperator.DefaultTheiaCloudOperatorLauncher",
+      "args": [
+        "--keycloak",
+        "--keycloakURL",
+        "https://${input:minikubeIP}.nip.io/keycloak/",
+        "--keycloakRealm",
+        "TheiaCloud",
+        "--keycloakClientId",
+        "theia-cloud",
+        "--usePaths",
+        "--instancesPath",
+        "instances",
+        "--instancesHost",
+        "${input:minikubeIP}.nip.io",
+        "--serviceUrl",
+        "https://${input:minikubeIP}.nip.io/service",
+        "--cloudProvider",
+        "MINIKUBE",
+        "--sessionsPerUser",
+        "3",
+        "--appId",
+        "asdfghjkl",
+        "--storageClassName",
+        "default",
+        "--requestedStorage",
+        "250Mi",
+        "--bandwidthLimiter",
+        "WONDERSHAPER",
+        "--oAuth2ProxyVersion",
+        "v7.5.1",
+        "--eagerStart"
+      ],
+      "vmArgs": "-Dlog4j2.configurationFile=log4j2.xml",
+      "preLaunchTask": "Build and Install Operator library"
+    },
+    {
       // Attach to the service running (Task: Run Service)
       "type": "java",
       "name": "Attach to Service",

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
@@ -2,6 +2,7 @@ package org.eclipse.theia.cloud.common.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
@@ -27,5 +28,14 @@ public class LabelsUtil {
         labels.put(LABEL_KEY_USER, sanitizedUser);
         labels.put(LABEL_KEY_APPDEF, appDefinitionSpec.getName());
         return labels;
+    }
+
+    /**
+     * Returns the set of label keys that are specific to a specific session, i.e. the user key.
+     * 
+     * @return The session specific label keys.
+     */
+    public static Set<String> getSessionSpecificLabelKeys() {
+        return Set.of(LABEL_KEY_USER);
     }
 }

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
@@ -31,6 +31,12 @@ public final class NamingUtil {
 
     public static final char VALID_NAME_SUFFIX = 'z';
 
+    /**
+     * Prefix for names generated based on an app definition and an index. These names are typically used for objects
+     * related to eagerly started instance pods (e.g. services or deployments).
+     */
+    public static final String APP_DEFINITION_INSTANCE_PREFIX = "instance-";
+
     private static final Locale US_LOCALE = new Locale("en", "US");
 
     private NamingUtil() {
@@ -41,7 +47,7 @@ public final class NamingUtil {
      * @see NamingUtil#createName(AppDefinition, int, String)
      */
     public static String createName(AppDefinition appDefinition, int instance) {
-        return createName(appDefinition, instance);
+        return createName(appDefinition, instance, null);
     }
 
     /**
@@ -56,10 +62,10 @@ public final class NamingUtil {
      * same type for an AppDefinition.
      * </p>
      * <p>
-     * The created name contains a "session" prefix, the session's user and app definition, the identifier (if given),
-     * and the last segment of the Session's UID. User, app definition and identifier are shortened to keep the name
-     * within Kubernetes' character limit (63) minus 6 characters. The latter allows Kubernetes to add 6 characters at
-     * the end of deployment pod names while the pod names pod names will still contain the whole name of the deployment
+     * The created name contains a "instance-" prefix, instance number, the identifier (if given), and the last segment
+     * of the App Definition's UID. User, app definition and identifier are shortened to keep the name within
+     * Kubernetes' character limit (63) minus 6 characters. The latter allows Kubernetes to add 6 characters at the end
+     * of deployment pod names while the pod names pod names will still contain the whole name of the deployment
      * </p>
      * 
      * @param appDefinition the {@link AppDefinition}
@@ -69,7 +75,7 @@ public final class NamingUtil {
      * @return the name
      */
     public static String createName(AppDefinition appDefinition, int instance, String identifier) {
-        String prefix = "instance-" + instance;
+        String prefix = APP_DEFINITION_INSTANCE_PREFIX + instance;
         return createName(prefix, identifier, null, appDefinition.getSpec().getName(),
                 appDefinition.getMetadata().getUid());
     }
@@ -174,7 +180,7 @@ public final class NamingUtil {
 
         // If the user is an email address, only take the part before the @ sign because
         // this is usually sufficient to identify the user.
-        String userName = user.split("@")[0];
+        String userName = user != null ? user.split("@")[0] : null;
 
         int infoSegmentLength;
         String shortenedIdentifier = null;

--- a/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
@@ -17,6 +17,8 @@ package org.eclipse.theia.cloud.common.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.workspace.Workspace;
@@ -29,6 +31,22 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
  * Unit tests for {@link NamingUtil}.
  */
 class NamingUtilTests {
+
+    @Test
+    void createName_AppDefinitionAndInstace() {
+        AppDefinition appDefinition = createAppDefinition();
+
+        String result = NamingUtil.createName(appDefinition, 1);
+        assertEquals("instance-1-some-app-definiti-381261d79c23", result);
+    }
+
+    @Test
+    void createName_AppDefinitionAndInstaceAndIdentifier() {
+        AppDefinition appDefinition = createAppDefinition();
+
+        String result = NamingUtil.createName(appDefinition, 1, "longidentifier");
+        assertEquals("instance-1-longidentif-some-app-de-381261d79c23", result);
+    }
 
     @Test
     void createName_SessionAndNullIdentifier() {
@@ -92,6 +110,21 @@ class NamingUtilTests {
 
         String result = NamingUtil.createName(workspace, "longidentifier");
         assertEquals("ws-longidentif-some-userna-test-app-de-381261d79c23", result);
+    }
+
+    private AppDefinition createAppDefinition() {
+        AppDefinition appDefinition = new AppDefinition();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setUid("6f1a8966-4d5a-41dc-82ba-381261d79c23");
+        appDefinition.setMetadata(objectMeta);
+        AppDefinitionSpec spec = new AppDefinitionSpec() {
+            @Override
+            public String getName() {
+                return "some-app-definition";
+            }
+        };
+        appDefinition.setSpec(spec);
+        return appDefinition;
     }
 
     private Session createSession() {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/AbstractTheiaCloudOperatorModule.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/AbstractTheiaCloudOperatorModule.java
@@ -31,7 +31,7 @@ import org.eclipse.theia.cloud.operator.bandwidth.BandwidthLimiterImpl;
 import org.eclipse.theia.cloud.operator.handler.appdef.AppDefinitionHandler;
 import org.eclipse.theia.cloud.operator.handler.appdef.EagerStartAppDefinitionAddedHandler;
 import org.eclipse.theia.cloud.operator.handler.appdef.LazyStartAppDefinitionHandler;
-import org.eclipse.theia.cloud.operator.handler.session.EagerStartSessionHandler;
+import org.eclipse.theia.cloud.operator.handler.session.EagerSessionHandler;
 import org.eclipse.theia.cloud.operator.handler.session.LazySessionHandler;
 import org.eclipse.theia.cloud.operator.handler.session.SessionHandler;
 import org.eclipse.theia.cloud.operator.handler.ws.LazyWorkspaceHandler;
@@ -143,7 +143,7 @@ public abstract class AbstractTheiaCloudOperatorModule extends AbstractModule {
 
     protected Class<? extends SessionHandler> bindSessionHandler() {
         if (arguments.isEagerStart()) {
-            return EagerStartSessionHandler.class;
+            return EagerSessionHandler.class;
         } else {
             return LazySessionHandler.class;
         }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudHandlerUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudHandlerUtil.java
@@ -73,6 +73,17 @@ public final class TheiaCloudHandlerUtil {
         return item;
     }
 
+    public static <T extends HasMetadata> T removeOwnerReferenceFromItem(String correlationId,
+            String sessionResourceName, String sessionResourceUID, T item) {
+        LOGGER.info(
+                formatLogMessage(correlationId, "Removing the owner reference from " + item.getMetadata().getName()));
+        item.getMetadata().getOwnerReferences().removeIf(ownerReference -> {
+            return ownerReference.getName().equals(sessionResourceName)
+                    && ownerReference.getUid().equals(sessionResourceUID);
+        });
+        return item;
+    }
+
     public static OwnerReference createOwnerReference(String sessionResourceName, String sessionResourceUID) {
         OwnerReference ownerReference = new OwnerReference();
         ownerReference.setApiVersion(HasMetadata.getApiVersion(Session.class));

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudK8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudK8sUtil.java
@@ -21,11 +21,11 @@ import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessag
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.OperatorStatus;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpecResourceList;
-import org.eclipse.theia.cloud.common.util.NamingUtil;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -69,14 +69,20 @@ public final class TheiaCloudK8sUtil {
         return currentInstances > appDefinitionSpec.getMaxInstances();
     }
 
+    /**
+     * Extracts the instance id from the name of a Kubernetes object whose name was generated based on an app definition
+     * and an id.
+     * 
+     * @param metadata The object's metadata
+     * @return the extracted identifier
+     * @see org.eclipse.theia.cloud.common.util.NamingUtil#createName(AppDefinition, int)
+     * @see org.eclipse.theia.cloud.common.util.NamingUtil#createName(AppDefinition, int, String)
+     */
     public static String extractIdFromName(ObjectMeta metadata) {
+        // Generated name is of the form "instance-<instanceId>-<further-name-segments>"
         String name = metadata.getName();
         String[] split = name.split("-");
-        String instance = split.length == 0 ? "" : split[0];
-        // kubernetes names must not start with letter, remove automatically added
-        // prefix
-        instance = instance.length() == 0 ? ""
-                : instance.charAt(0) == NamingUtil.VALID_NAME_PREFIX ? instance.substring(1) : instance;
+        String instance = split.length < 2 ? "" : split[1];
         return instance;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
@@ -132,6 +132,15 @@ public final class TheiaCloudServiceUtil {
         return service.getMetadata().getOwnerReferences().size() == 1;
     }
 
+    /**
+     * Returns an unused service.
+     * 
+     * @param existingServices
+     * @return
+     * @deprecated Use {@link #getUnusedService(List, String)} instead: Services should be owned by the corresponding
+     *             app definition.
+     */
+    @Deprecated
     public static Optional<Service> getUnusedService(List<Service> existingServices) {
         Optional<Service> serviceToUse = existingServices.stream()//
                 .filter(TheiaCloudServiceUtil::isUnusedService)//
@@ -139,4 +148,25 @@ public final class TheiaCloudServiceUtil {
         return serviceToUse;
     }
 
+    /**
+     * Returns an unused service that is owned by the given app definition.
+     * 
+     * @param existingServices         The list of services to search in.
+     * @param appDefinitionResourceUID The UID of the app definition that should own the service.
+     * @return The unused service that is owned by the given app definition or nothing if none is available.
+     */
+    public static Optional<Service> getUnusedService(List<Service> existingServices, String appDefinitionResourceUID) {
+        Optional<Service> serviceToUse = existingServices.stream()//
+                .filter(TheiaCloudServiceUtil::isUnusedService)//
+                .filter(service -> {
+                    for (OwnerReference ownerReference : service.getMetadata().getOwnerReferences()) {
+                        if (appDefinitionResourceUID.equals(ownerReference.getUid())) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })//
+                .findAny();
+        return serviceToUse;
+    };
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
@@ -100,6 +100,10 @@ public class BaseResource {
         logger.warn(LogMessageUtil.formatLogMessage(correlationId, message));
     }
 
+    public void warn(String correlationId, String message, Throwable throwable) {
+        logger.warn(LogMessageUtil.formatLogMessage(correlationId, message), throwable);
+    }
+
     public void error(String correlationId, String message) {
         logger.error(LogMessageUtil.formatLogMessage(correlationId, message));
     }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/K8sUtil.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/K8sUtil.java
@@ -18,6 +18,7 @@ package org.eclipse.theia.cloud.service;
 
 import static org.eclipse.theia.cloud.common.util.WorkspaceUtil.getSessionName;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -37,11 +38,11 @@ import org.eclipse.theia.cloud.service.session.SessionPerformance;
 import org.eclipse.theia.cloud.service.workspace.UserWorkspace;
 import org.jboss.logging.Logger;
 
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics;
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -154,11 +155,15 @@ public final class K8sUtil {
     public SessionPerformance reportPerformance(String sessionName) {
         Optional<Session> optionalSession = CLIENT.sessions().get(sessionName);
         if (optionalSession.isEmpty()) {
+            logger.warn(MessageFormat.format("Cannot get performance data for session {0} because it does not exist.",
+                    sessionName));
             return null;
         }
         Session session = optionalSession.get();
         Optional<Pod> optionalPod = getPodForSession(session);
         if (optionalPod.isEmpty()) {
+            logger.warn(MessageFormat.format("Cannot get performance data for session {0} because no pod was found.",
+                    sessionName));
             return null;
         }
         PodMetrics test = CLIENT.kubernetes().top().pods().metrics(CLIENT.namespace(),
@@ -166,6 +171,9 @@ public final class K8sUtil {
         Optional<ContainerMetrics> optionalContainer = test.getContainers().stream()
                 .filter(con -> con.getName().equals(session.getSpec().getAppDefinition())).findFirst();
         if (optionalContainer.isEmpty()) {
+            logger.warn(MessageFormat.format(
+                    "Cannot get performance data for session {0} because the app container was not found in the pod.",
+                    sessionName));
             return null;
         }
         ContainerMetrics container = optionalContainer.get();
@@ -179,20 +187,39 @@ public final class K8sUtil {
         return podlist.getItems().stream().filter(pod -> isPodFromSession(pod, session)).findFirst();
     }
 
+    /**
+     * Checks whether a Pod belongs to a Session by resolving the Pod's Deployment and checking whether the Deployment
+     * is owned by the Session.
+     */
     private boolean isPodFromSession(Pod pod, Session session) {
-        Optional<Container> optionalContainer = pod.getSpec().getContainers().stream()
-                .filter(con -> con.getName().equals(session.getSpec().getAppDefinition())).findFirst();
-        if (optionalContainer.isEmpty()) {
-            return false;
-        }
-        Container container = optionalContainer.get();
-        Optional<EnvVar> optionalEnv = container.getEnv().stream()
-                .filter(env -> env.getName().equals("THEIACLOUD_SESSION_NAME")).findFirst();
-        if (optionalEnv.isEmpty()) {
-            return false;
-        }
-        EnvVar env = optionalEnv.get();
-        return env.getValue().equals(session.getSpec().getName());
+        return getDeploymentForPod(pod)//
+                .flatMap(deployment -> deployment.getOwnerReferenceFor(session.getMetadata().getUid()))//
+                .isPresent();
+    }
+
+    /**
+     * <p>
+     * Returns the Deployment associated with a given Pod.
+     * </p>
+     * <p>
+     * The deployment is retrieved by following the owner references of the Pod. The Pod's owner references are filtered
+     * to find the ReplicaSet. Then, the ReplicaSet's owner references are filtered to find the Deployment and return
+     * it.
+     * </p>
+     *
+     * @param Pod the Pod for which to retrieve the Deployment.
+     * @return the Deployment associated with the given Pod or an empty Optional if not found.
+     */
+    private Optional<Deployment> getDeploymentForPod(Pod pod) {
+        Optional<ReplicaSet> replicaSet = pod.getMetadata().getOwnerReferences().stream()
+                .filter(ownerReference -> "ReplicaSet".equals(ownerReference.getKind()))
+                .map(ownerReference -> CLIENT.apps().replicaSets().withName(ownerReference.getName()).get())
+                .filter(Objects::nonNull).findFirst();
+
+        return replicaSet.flatMap(rs -> rs.getMetadata().getOwnerReferences().stream()
+                .filter(rsOwnerReference -> "Deployment".equals(rsOwnerReference.getKind()))
+                .map(rsOwnerReference -> CLIENT.apps().deployments().withName(rsOwnerReference.getName()).get())
+                .filter(Objects::nonNull).findFirst());
     }
 
     public boolean hasAppDefinition(String appDefinition) {
@@ -212,9 +239,11 @@ public final class K8sUtil {
         if (maxInstances < 0) {
             return false; // max instances is set to negative, so we can ignore it
         }
-        long podsOfAppDef = CLIENT.sessions().list().stream() // All sessions
+
+        long sessionsOfAppDef = CLIENT.sessions().list().stream() // All sessions
                 .filter(s -> s.getSpec().getAppDefinition().equals(appDefString)) // That are from the appDefinition
-                .filter(s -> getPodForSession(s).isPresent()).count(); // That already have a pod
-        return podsOfAppDef >= maxInstances;
+                .filter(s -> s.getStatus() == null || !s.getStatus().hasError()) // That are not in error state
+                .count();
+        return sessionsOfAppDef >= maxInstances;
     }
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionResource.java
@@ -162,7 +162,7 @@ public class SessionResource extends BaseResource {
         try {
             performance = k8sUtil.reportPerformance(sessionName);
         } catch (Exception e) {
-            trace(correlationId, "", e);
+            warn(correlationId, "", e);
             performance = null;
         }
         if (performance == null) {

--- a/node/testing-page/src/App.tsx
+++ b/node/testing-page/src/App.tsx
@@ -12,7 +12,8 @@ import {
   WorkspaceDeletionRequest,
   WorkspaceListRequest,
   PingRequest,
-  LaunchRequest
+  LaunchRequest,
+  SessionPerformanceRequest
 } from '@eclipse-theiacloud/common';
 
 const KEYCLOAK_CONFIG: KeycloakConfig = {
@@ -159,6 +160,14 @@ function App() {
     };
     return TheiaCloud.Session.stopSession(request, generateRequestOptions(accessToken));
   };
+  const reportSessionPerformance = (user: string, accessToken?: string) => {
+    const request: SessionPerformanceRequest = {
+      appId: APP_ID,
+      sessionName: resourceName,
+      serviceUrl: SERVICE_URL
+    };
+    return TheiaCloud.Session.getSessionPerformance(request, generateRequestOptions(accessToken));
+  };
 
   // App definition requests
   const listAppDefinitions = (user: string, accessToken?: string) => {
@@ -197,6 +206,7 @@ function App() {
         <button onClick={() => executeRequest(listSessions)}>List Sessions</button>
         <button onClick={() => executeRequest(startSession)}>Start Session</button>
         <button onClick={() => executeRequest(stopSession)}>Stop Session</button>
+        <button onClick={() => executeRequest(reportSessionPerformance)}>Report Session Performance</button>
       </p>
       <p>
         <button onClick={() => executeRequest(listWorkspaces)}>List Workspaces</button>

--- a/terraform/test-configurations/2-04_try-now_paths_eager-start/.terraform.lock.hcl
+++ b/terraform/test-configurations/2-04_try-now_paths_eager-start/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = ">= 1.14.0"
+  hashes = [
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.9.0"
+  constraints = ">= 2.9.0"
+  hashes = [
+    "h1:D5BLFN82WndhQZQleXE5rO0hUDnlyqb60XeUJKDhuo4=",
+    "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
+    "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
+    "zh:1b10ae03cf5ab1ae21ffaac2251de99797294ae4242b156b3b0beebbdbcb7e0f",
+    "zh:3bd043b68de967d8d0b549d3f71485193d81167d5656f5507d743dedfe60e352",
+    "zh:538911921c729185900176cc22eb8edcb822bc8d22b9ebb48103a1d9bb53cc38",
+    "zh:69a6a2d40c0463662c3fb1621e37a3ee65024ea4479adf4d5f7f19fb0dea48c2",
+    "zh:94b58daa0c351a49d01f6d8f1caae46c95c2d6c3f29753e2b9ea3e3c0e7c9ab4",
+    "zh:9d0543331a4a32241e1ab5457f30b41df745acb235a0391205c725a5311e4809",
+    "zh:a6789306524ca121512a95e873e3949b4175114a6c5db32bed2df2551a79368f",
+    "zh:d146b94cd9502cca7f2044797a328d71c7ec2a98e2d138270d8a28c872f04289",
+    "zh:d14ccd14511f0446eacf43a9243f22de7c1427ceb059cf67d7bf9803be2cb15d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/test-configurations/2-04_try-now_paths_eager-start/README.md
+++ b/terraform/test-configurations/2-04_try-now_paths_eager-start/README.md
@@ -1,0 +1,12 @@
+# Eager start test config
+
+This contains a test configuration for eagerly started pods.
+It does not use persistent workspaces.
+
+It installs two appdefinitions:
+
+- The default app defintion with 0 mininum instances and 10 maximum instances.
+  - No pre-warmed pod is started for this
+- A CDT cloud app definition with name `cdt-cloud-demo` with 1 minimum instance and 10 maximum instances.
+  - 1 pre-warmed pod is started for this.
+  - This may be adjusted by increasing the `minInstances` property of the app definition in [theia_cloud.tf](./theia_cloud.tf).

--- a/terraform/test-configurations/2-04_try-now_paths_eager-start/outputs.tf
+++ b/terraform/test-configurations/2-04_try-now_paths_eager-start/outputs.tf
@@ -1,0 +1,15 @@
+output "service" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/service"
+}
+
+output "instance" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/instances"
+}
+
+output "keycloak" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/keycloak/"
+}
+
+output "landing" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/try"
+}

--- a/terraform/test-configurations/2-04_try-now_paths_eager-start/theia_cloud.tf
+++ b/terraform/test-configurations/2-04_try-now_paths_eager-start/theia_cloud.tf
@@ -1,0 +1,126 @@
+data "terraform_remote_state" "minikube" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../0_minikube-setup/terraform.tfstate"
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.terraform_remote_state.minikube.outputs.host
+    client_certificate     = data.terraform_remote_state.minikube.outputs.client_certificate
+    client_key             = data.terraform_remote_state.minikube.outputs.client_key
+    cluster_ca_certificate = data.terraform_remote_state.minikube.outputs.cluster_ca_certificate
+  }
+}
+
+provider "kubectl" {
+  load_config_file       = false
+  host                   = data.terraform_remote_state.minikube.outputs.host
+  client_certificate     = data.terraform_remote_state.minikube.outputs.client_certificate
+  client_key             = data.terraform_remote_state.minikube.outputs.client_key
+  cluster_ca_certificate = data.terraform_remote_state.minikube.outputs.cluster_ca_certificate
+}
+
+resource "helm_release" "theia-cloud" {
+  name             = "theia-cloud"
+  chart            = "../../../../theia-cloud-helm/charts/theia-cloud"
+  namespace        = "theia-cloud"
+  create_namespace = true
+
+  values = [
+    "${file("${path.module}/../../values/valuesDemo.yaml")}"
+  ]
+
+  set {
+    name = "hosts.usePaths"
+    # Need to hand in boolean as string as terraform converts boolean to 1 resp. 0.
+    # See https://github.com/hashicorp/terraform-provider-helm/issues/208
+    value = "true"
+  }
+
+  set {
+    name  = "ingress.addTLSSecretName"
+    value = "true"
+  }
+
+  set {
+    name  = "hosts.configuration.service"
+    value = "service"
+  }
+
+  set {
+    name  = "hosts.configuration.landing"
+    value = "try"
+  }
+
+  set {
+    name  = "hosts.configuration.instance"
+    value = "instances"
+  }
+
+
+  set {
+    name  = "hosts.configuration.baseHost"
+    value = data.terraform_remote_state.minikube.outputs.hostname
+  }
+
+  set {
+    name  = "keycloak.authUrl"
+    value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/keycloak/"
+  }
+
+  set {
+    name  = "operator.cloudProvider"
+    value = "MINIKUBE"
+  }
+
+  set {
+    name  = "operator.eagerStart"
+    value = true
+  }
+
+  set {
+    name  = "ingress.clusterIssuer"
+    value = "theia-cloud-selfsigned-issuer"
+  }
+
+  set {
+    name  = "ingress.theiaCloudCommonName"
+    value = true
+  }
+
+  # Only pull missing images. This is needed to use images built locally in Minikube
+  set {
+    name  = "imagePullPolicy"
+    value = "IfNotPresent"
+  }
+}
+
+resource "kubectl_manifest" "cdt-cloud-demo" {
+  depends_on = [helm_release.theia-cloud]
+  yaml_body  = <<-EOF
+  apiVersion: theia.cloud/v1beta10
+  kind: AppDefinition
+  metadata:
+    name: cdt-cloud-demo
+    namespace: theia-cloud
+  spec:
+    downlinkLimit: 30000
+    image: theiacloud/cdt-cloud:v1.43.1
+    imagePullPolicy: IfNotPresent
+    ingressname: theia-cloud-demo-ws-ingress
+    limitsCpu: "2"
+    limitsMemory: 1200M
+    maxInstances: 10
+    minInstances: 1
+    name: cdt-cloud-demo
+    port: 3000
+    requestsCpu: 100m
+    requestsMemory: 1000M
+    timeout: 30
+    uid: 101
+    uplinkLimit: 30000
+  EOF
+}

--- a/terraform/test-configurations/2-04_try-now_paths_eager-start/versions.tf
+++ b/terraform/test-configurations/2-04_try-now_paths_eager-start/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}

--- a/terraform/test-configurations/test.md
+++ b/terraform/test-configurations/test.md
@@ -21,4 +21,6 @@ terraform state rm kubernetes_persistent_volume.minikube
 Pick an installation in one of below directories and run `terraform init` and `terraform apply`.
 
 - `2-01_try-now` installs a local version of <https://try.theia-cloud.io/>
-- `2-02_monitor-vscode` installs a setup that allows to test the vscode monitor with and without authentication
+- `2-02_monitor` installs a setup that allows to test the monitor (VSCode extension or Theia extension based) with and without authentication
+- `2-03_try-now_paths` installs a local version of <https://try.theia-cloud.io/> using paths instead of subdomains.
+- `2-04_try-now_paths_eager-start` installs a local version of <https://try.theia-cloud.io/> using paths and eager instead of lazy starting of pods. See its [README](./2-04_try-now_paths_eager-start/README.md) for more details.


### PR DESCRIPTION
Requires:
- https://github.com/eclipse-theia/theia-cloud-helm/pull/86

## Summary
This pull request addresses critical issues in the eager start handling, which was previously broken, and introduces improvements to naming, session management, pod synchronization, and performance in Kubernetes environments.

## Details

### Common
- Name Handling for Eager Start:
  - Resolved an endless loop and a NullPointerException (NPE) in NamingUtil methods.
  - Fixed ID extraction from generated names to align with updates from an [earlier PR](https://github.com/eclipse-theia/theia-cloud/pull/326).

### Operator - Eager Session Handling

- Added annotations to trigger ConfigMap updates for OAuth proxy synchronization in pods. This ensures, the assigned user can actually access the pod immediately after redirection
- Implemented session cleanup and pod restart logic in the renamed EagerSessionHandler.


### Service

- Enhanced max instance checks to consider sessions relevant to the app definition instead of analyzing all pods.
- Updated pod resolution logic to rely on owner references instead of environment variables, ensuring compatibility with eager start mode.
- Improved logging and performance reporting in K8sUtil and the performance REST handler.

### Testing

- Added a Terraform test configuration for eager start mode.
- Added a VS Code launch config to start the operator in eager mode for the new Terraform config
- Extend testing page with a button to get session performance data

## Notes on Testing

- You need the corresponding Theia Cloud Helm changes from PR https://github.com/eclipse-theia/theia-cloud-helm/pull/86 for the changes to work as they require additional K8S permissions for the operator and service.
- I think all of our test setups currently do not configure snippet enablement for the nginx ingress of Minikube. This must be done manually. See here how to do this: https://github.com/eclipse-theia/theia-cloud-helm?tab=readme-ov-file#cluster-prerequisites . We should probably fix this in general in a separate PR.
- The default Theia Cloud IDE app is not supposed to work in eager mode as it has 0 `minInstances` and currently lazy starting up until maxInstances is not supported (and maybe never will be). Use the CDT cloud app.