### PR TITLE
Fix reusable-theia-extension workflow

### DIFF
--- a/.github/workflows/reusable-theia-extension.yml
+++ b/.github/workflows/reusable-theia-extension.yml
@@ -30,7 +30,7 @@ jobs:
         if: github.event_name == 'push'
         id: version_check
         run: |
-          VERSION=$(cd extensions/${{ inputs.package_workspace }} && node --print "require('./package.json').version")
+          VERSION=$(cd ${{ inputs.package_workspace }} && node --print "require('./package.json').version")
           echo "Package version: ${VERSION}"
           if [[ $VERSION == *"-next" ]]; then
             echo "is_next_version=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remove hardcoded `extensions/` prefix to align with the other commands using workflow input `package_workspace`