### PR TITLE
service: Add admin user concept and app definition scaling endpoint

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,7 +60,7 @@
         "-Dtheia.cloud.app.id=asdfghjkl",
         "-Dquarkus.http.port=8081",
         "-Dtheia.cloud.use.keycloak=true",
-        "-Dquarkus.oidc.auth-server-url=${input:keycloakURL}",
+        "-Dquarkus.oidc.auth-server-url=${input:keycloakURL}/realms/TheiaCloud",
         "-Dquarkus.oidc.client-id=theia-cloud",
         "-Dquarkus.oidc.credentials.secret=publicbutoauth2proxywantsasecret"
       ],
@@ -101,7 +101,7 @@
       "type": "promptString",
       "id": "keycloakURL",
       "description": "Provide the keycloak url",
-      "default": "https://192.168.59.101.nip.io/keycloak/"
+      "default": "https://192.168.59.101.nip.io/keycloak"
     }
   ]
 }

--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -22,9 +22,11 @@ ENV KEYCLOAK_ENABLE true
 ENV KEYCLOAK_SERVERURL https://keycloak.url/auth/realms/TheiaCloud
 ENV KEYCLOAK_CLIENTID theia-cloud
 ENV KEYCLOAK_CLIENTSECRET publicbutoauth2proxywantsasecret
+ENV KEYCLOAK_ADMIN_GROUP theia-cloud/admin
 
 ENTRYPOINT java -Dtheia.cloud.app.id=${APPID} \
     -Dquarkus.http.port=${SERVICE_PORT} \
+    -Dtheia.cloud.auth.admin.group=${KEYCLOAK_ADMIN_GROUP} \
     -Dtheia.cloud.use.keycloak=${KEYCLOAK_ENABLE} \
     -Dquarkus.oidc.auth-server-url=${KEYCLOAK_SERVERURL} \
     -Dquarkus.oidc.client-id=${KEYCLOAK_CLIENTID} \

--- a/documentation/api/Apis/AppDefinitionAdminResourceApi.md
+++ b/documentation/api/Apis/AppDefinitionAdminResourceApi.md
@@ -1,0 +1,37 @@
+# AppDefinitionAdminResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceAdminAppdefinitionAppDefinitionNamePatch**](AppDefinitionAdminResourceApi.md#serviceAdminAppdefinitionAppDefinitionNamePatch) | **PATCH** /service/admin/appdefinition/{appDefinitionName} | Updates an app definition |
+
+
+<a name="serviceAdminAppdefinitionAppDefinitionNamePatch"></a>
+# **serviceAdminAppdefinitionAppDefinitionNamePatch**
+> AppDefinition serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName, AppDefinitionUpdateRequest)
+
+Updates an app definition
+
+    Updates an app definition&#39;s properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appDefinitionName** | **String**| The K8S resource name of the app definition to update. | [default to null] |
+| **AppDefinitionUpdateRequest** | [**AppDefinitionUpdateRequest**](../Models/AppDefinitionUpdateRequest.md)|  | |
+
+### Return type
+
+[**AppDefinition**](../Models/AppDefinition.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/documentation/api/Apis/RootAdminResourceApi.md
+++ b/documentation/api/Apis/RootAdminResourceApi.md
@@ -1,0 +1,36 @@
+# RootAdminResourceApi
+
+All URIs are relative to *http://localhost*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**serviceAdminAppIdGet**](RootAdminResourceApi.md#serviceAdminAppIdGet) | **GET** /service/admin/{appId} | Admin Ping |
+
+
+<a name="serviceAdminAppIdGet"></a>
+# **serviceAdminAppIdGet**
+> Boolean serviceAdminAppIdGet(appId)
+
+Admin Ping
+
+    Replies with success if the service is available and the user an admin.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **appId** | **String**|  | [default to null] |
+
+### Return type
+
+**Boolean**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+

--- a/documentation/api/Apis/RootResourceApi.md
+++ b/documentation/api/Apis/RootResourceApi.md
@@ -47,7 +47,7 @@ Launch Session
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **LaunchRequest** | [**LaunchRequest**](../Models/LaunchRequest.md)|  | [optional] |
+| **LaunchRequest** | [**LaunchRequest**](../Models/LaunchRequest.md)|  | |
 
 ### Return type
 

--- a/documentation/api/Apis/SessionResourceApi.md
+++ b/documentation/api/Apis/SessionResourceApi.md
@@ -51,7 +51,7 @@ Stop session
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **SessionStopRequest** | [**SessionStopRequest**](../Models/SessionStopRequest.md)|  | [optional] |
+| **SessionStopRequest** | [**SessionStopRequest**](../Models/SessionStopRequest.md)|  | |
 
 ### Return type
 
@@ -78,7 +78,7 @@ Report session activity
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **SessionActivityRequest** | [**SessionActivityRequest**](../Models/SessionActivityRequest.md)|  | [optional] |
+| **SessionActivityRequest** | [**SessionActivityRequest**](../Models/SessionActivityRequest.md)|  | |
 
 ### Return type
 
@@ -133,7 +133,7 @@ Start a new session
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **SessionStartRequest** | [**SessionStartRequest**](../Models/SessionStartRequest.md)|  | [optional] |
+| **SessionStartRequest** | [**SessionStartRequest**](../Models/SessionStartRequest.md)|  | |
 
 ### Return type
 

--- a/documentation/api/Apis/WorkspaceResourceApi.md
+++ b/documentation/api/Apis/WorkspaceResourceApi.md
@@ -49,7 +49,7 @@ Delete workspace
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **WorkspaceDeletionRequest** | [**WorkspaceDeletionRequest**](../Models/WorkspaceDeletionRequest.md)|  | [optional] |
+| **WorkspaceDeletionRequest** | [**WorkspaceDeletionRequest**](../Models/WorkspaceDeletionRequest.md)|  | |
 
 ### Return type
 
@@ -76,7 +76,7 @@ Create workspace
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **WorkspaceCreationRequest** | [**WorkspaceCreationRequest**](../Models/WorkspaceCreationRequest.md)|  | [optional] |
+| **WorkspaceCreationRequest** | [**WorkspaceCreationRequest**](../Models/WorkspaceCreationRequest.md)|  | |
 
 ### Return type
 

--- a/documentation/api/Models/AppDefinition.md
+++ b/documentation/api/Models/AppDefinition.md
@@ -1,0 +1,21 @@
+# AppDefinition
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **apiVersion** | **String** |  | [optional] [default to null] |
+| **kind** | **String** |  | [optional] [default to null] |
+| **metadata** | [**ObjectMeta**](ObjectMeta.md) |  | [optional] [default to null] |
+| **spec** | [**AppDefinitionSpec**](AppDefinitionSpec.md) |  | [optional] [default to null] |
+| **status** | [**AppDefinitionStatus**](AppDefinitionStatus.md) |  | [optional] [default to null] |
+| **singular** | **String** |  | [optional] [default to null] |
+| **crdName** | **String** |  | [optional] [default to null] |
+| **scope** | **String** |  | [optional] [default to null] |
+| **plural** | **String** |  | [optional] [default to null] |
+| **served** | **Boolean** |  | [optional] [default to null] |
+| **storage** | **Boolean** |  | [optional] [default to null] |
+| **deprecated** | **Boolean** |  | [optional] [default to null] |
+| **deprecationWarning** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/AppDefinitionStatus.md
+++ b/documentation/api/Models/AppDefinitionStatus.md
@@ -1,0 +1,10 @@
+# AppDefinitionStatus
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **operatorStatus** | **String** |  | [optional] [default to null] |
+| **operatorMessage** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/AppDefinitionUpdateRequest.md
+++ b/documentation/api/Models/AppDefinitionUpdateRequest.md
@@ -1,0 +1,11 @@
+# AppDefinitionUpdateRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **appId** | **String** | The App Id of this Theia Cloud instance. Request without a matching Id will be denied. | [default to null] |
+| **minInstances** | **Integer** | The minimum number of instances to run. | [optional] [default to null] |
+| **maxInstances** | **Integer** | The maximum number of instances to run. | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/ManagedFieldsEntry.md
+++ b/documentation/api/Models/ManagedFieldsEntry.md
@@ -1,0 +1,15 @@
+# ManagedFieldsEntry
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **apiVersion** | **String** |  | [optional] [default to null] |
+| **fieldsType** | **String** |  | [optional] [default to null] |
+| **fieldsV1** | [**Object**](.md) |  | [optional] [default to null] |
+| **manager** | **String** |  | [optional] [default to null] |
+| **operation** | **String** |  | [optional] [default to null] |
+| **subresource** | **String** |  | [optional] [default to null] |
+| **time** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/ObjectMeta.md
+++ b/documentation/api/Models/ObjectMeta.md
@@ -1,0 +1,23 @@
+# ObjectMeta
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **annotations** | **Map** |  | [optional] [default to null] |
+| **creationTimestamp** | **String** |  | [optional] [default to null] |
+| **deletionGracePeriodSeconds** | **Long** |  | [optional] [default to null] |
+| **deletionTimestamp** | **String** |  | [optional] [default to null] |
+| **finalizers** | **List** |  | [optional] [default to null] |
+| **generateName** | **String** |  | [optional] [default to null] |
+| **generation** | **Long** |  | [optional] [default to null] |
+| **labels** | **Map** |  | [optional] [default to null] |
+| **managedFields** | [**List**](ManagedFieldsEntry.md) |  | [optional] [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
+| **namespace** | **String** |  | [optional] [default to null] |
+| **ownerReferences** | [**List**](OwnerReference.md) |  | [optional] [default to null] |
+| **resourceVersion** | **String** |  | [optional] [default to null] |
+| **selfLink** | **String** |  | [optional] [default to null] |
+| **uid** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/Models/OwnerReference.md
+++ b/documentation/api/Models/OwnerReference.md
@@ -1,0 +1,14 @@
+# OwnerReference
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **apiVersion** | **String** |  | [optional] [default to null] |
+| **kind** | **String** |  | [optional] [default to null] |
+| **blockOwnerDeletion** | **Boolean** |  | [optional] [default to null] |
+| **controller** | **Boolean** |  | [optional] [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
+| **uid** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/documentation/api/README.md
+++ b/documentation/api/README.md
@@ -7,7 +7,9 @@ All URIs are relative to *http://localhost*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
+| *AppDefinitionAdminResourceApi* | [**serviceAdminAppdefinitionAppDefinitionNamePatch**](Apis/AppDefinitionAdminResourceApi.md#serviceadminappdefinitionappdefinitionnamepatch) | **PATCH** /service/admin/appdefinition/{appDefinitionName} | Updates an app definition |
 | *AppDefinitionResourceApi* | [**serviceAppdefinitionAppIdGet**](Apis/AppDefinitionResourceApi.md#serviceappdefinitionappidget) | **GET** /service/appdefinition/{appId} | List app definitions |
+| *RootAdminResourceApi* | [**serviceAdminAppIdGet**](Apis/RootAdminResourceApi.md#serviceadminappidget) | **GET** /service/admin/{appId} | Admin Ping |
 | *RootResourceApi* | [**serviceAppIdGet**](Apis/RootResourceApi.md#serviceappidget) | **GET** /service/{appId} | Ping |
 *RootResourceApi* | [**servicePost**](Apis/RootResourceApi.md#servicepost) | **POST** /service | Launch Session |
 | *SessionResourceApi* | [**serviceSessionAppIdUserGet**](Apis/SessionResourceApi.md#servicesessionappiduserget) | **GET** /service/session/{appId}/{user} | List sessions |
@@ -24,11 +26,17 @@ All URIs are relative to *http://localhost*
 ## Documentation for Models
 
  - [ActivityTracker](./Models/ActivityTracker.md)
+ - [AppDefinition](./Models/AppDefinition.md)
  - [AppDefinitionListRequest](./Models/AppDefinitionListRequest.md)
  - [AppDefinitionSpec](./Models/AppDefinitionSpec.md)
+ - [AppDefinitionStatus](./Models/AppDefinitionStatus.md)
+ - [AppDefinitionUpdateRequest](./Models/AppDefinitionUpdateRequest.md)
  - [EnvironmentVars](./Models/EnvironmentVars.md)
  - [LaunchRequest](./Models/LaunchRequest.md)
+ - [ManagedFieldsEntry](./Models/ManagedFieldsEntry.md)
  - [Monitor](./Models/Monitor.md)
+ - [ObjectMeta](./Models/ObjectMeta.md)
+ - [OwnerReference](./Models/OwnerReference.md)
  - [PingRequest](./Models/PingRequest.md)
  - [SessionActivityRequest](./Models/SessionActivityRequest.md)
  - [SessionListRequest](./Models/SessionListRequest.md)

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1,495 +1,81 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "Theia Cloud API",
-    "version": "1.1.0"
-  },
-  "paths": {
-    "/service": {
-      "post": {
-        "tags": ["Root Resource"],
-        "summary": "Launch Session",
-        "description": "Launches a session and creates a workspace if required. Responds with the URL of the launched session.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LaunchRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/appdefinition/{appId}": {
-      "get": {
-        "tags": ["App Definition Resource"],
-        "summary": "List app definitions",
-        "description": "List available app definitions.",
-        "parameters": [
-          {
-            "name": "appId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AppDefinitionSpec"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/session": {
-      "post": {
-        "tags": ["Session Resource"],
-        "summary": "Start a new session",
-        "description": "Starts a new session for an existing workspace and responds with the URL of the started session.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SessionStartRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": ["Session Resource"],
-        "summary": "Stop session",
-        "description": "Stops a session.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SessionStopRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      },
-      "patch": {
-        "tags": ["Session Resource"],
-        "summary": "Report session activity",
-        "description": "Updates the last activity timestamp for a session to monitor activity.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SessionActivityRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/session/performance/{appId}/{sessionName}": {
-      "get": {
-        "tags": ["Session Resource"],
-        "summary": "Get performance metrics",
-        "description": "Returns the current CPU and memory usage of the session's pod.",
-        "parameters": [
-          {
-            "name": "appId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "sessionName",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionPerformance"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/session/{appId}/{user}": {
-      "get": {
-        "tags": ["Session Resource"],
-        "summary": "List sessions",
-        "description": "List sessions of a user.",
-        "parameters": [
-          {
-            "name": "appId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SessionSpec"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/workspace": {
-      "post": {
-        "tags": ["Workspace Resource"],
-        "summary": "Create workspace",
-        "description": "Creates a new workspace for a user.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceCreationRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserWorkspace"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": ["Workspace Resource"],
-        "summary": "Delete workspace",
-        "description": "Deletes a workspace.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceDeletionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/workspace/{appId}/{user}": {
-      "get": {
-        "tags": ["Workspace Resource"],
-        "summary": "List workspaces",
-        "description": "Lists the workspaces of a user.",
-        "parameters": [
-          {
-            "name": "appId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserWorkspace"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    },
-    "/service/{appId}": {
-      "get": {
-        "tags": ["Root Resource"],
-        "summary": "Ping",
-        "description": "Replies if the service is available.",
-        "parameters": [
-          {
-            "name": "appId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not Authorized"
-          },
-          "403": {
-            "description": "Not Allowed"
-          }
-        },
-        "security": [
-          {
-            "SecurityScheme": []
-          }
-        ]
-      }
-    }
-  },
+  "openapi": "3.1.0",
   "components": {
     "schemas": {
       "ActivityTracker": {
         "type": "object",
         "properties": {
           "timeoutAfter": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "notifyAfter": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "AppDefinition": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string",
+            "readOnly": true
+          },
+          "kind": {
+            "type": "string",
+            "readOnly": true
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/ObjectMeta"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/AppDefinitionSpec"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AppDefinitionStatus"
+          },
+          "singular": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "crdName": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "plural": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "served": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "storage": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "deprecated": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "deprecationWarning": {
+            "type": "string",
+            "writeOnly": true
           }
         }
       },
       "AppDefinitionListRequest": {
-        "description": "A request to list available app definitions.",
-        "required": ["appId"],
         "type": "object",
+        "required": ["appId"],
+        "description": "A request to list available app definitions.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           }
         }
       },
@@ -509,27 +95,27 @@
             "type": "string"
           },
           "uid": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "port": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "ingressname": {
             "type": "string"
           },
           "minInstances": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "maxInstances": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "timeout": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "requestsMemory": {
             "type": "string"
@@ -544,12 +130,12 @@
             "type": "string"
           },
           "downlinkLimit": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uplinkLimit": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "mountPath": {
             "type": "string"
@@ -571,75 +157,131 @@
           }
         }
       },
-      "EnvironmentVars": {
-        "description": "An object to hold all the ways environment variables can be passed. Not to be used by itself.",
+      "AppDefinitionStatus": {
         "type": "object",
         "properties": {
-          "fromMap": {
-            "description": "Map of environment variables to be passed to Deployment.  Ignored if Theia applications are started eagerly.  Empty by default.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+          "operatorStatus": {
+            "type": "string"
           },
-          "fromConfigMaps": {
-            "description": "List of ConfigMaps (by name) containing environment variables to be passed to Deployment as envFrom.configMapRef.  Ignored if Theia applications are started eagerly.  Empty by default.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "fromSecrets": {
-            "description": "List of Secrets (by name) containing environment variables to be passed to Deployment as envFrom.secretRef.  Ignored if Theia applications are started eagerly.  Empty by default.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "operatorMessage": {
+            "type": "string"
           }
         }
       },
-      "LaunchRequest": {
-        "description": "A request to launch a new session.",
-        "required": ["appId", "user"],
+      "AppDefinitionUpdateRequest": {
         "type": "object",
+        "required": ["appId"],
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
+          },
+          "minInstances": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The minimum number of instances to run."
+          },
+          "maxInstances": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The maximum number of instances to run."
+          }
+        }
+      },
+      "EnvironmentVars": {
+        "type": "object",
+        "description": "An object to hold all the ways environment variables can be passed. Not to be used by itself.",
+        "properties": {
+          "fromMap": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Map of environment variables to be passed to Deployment.  Ignored if Theia applications are started eagerly.  Empty by default."
+          },
+          "fromConfigMaps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of ConfigMaps (by name) containing environment variables to be passed to Deployment as envFrom.configMapRef.  Ignored if Theia applications are started eagerly.  Empty by default."
+          },
+          "fromSecrets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of Secrets (by name) containing environment variables to be passed to Deployment as envFrom.secretRef.  Ignored if Theia applications are started eagerly.  Empty by default."
+          }
+        }
+      },
+      "FieldsV1": {
+        "type": "object"
+      },
+      "LaunchRequest": {
+        "type": "object",
+        "required": ["appId", "user"],
+        "description": "A request to launch a new session.",
+        "properties": {
+          "appId": {
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "appDefinition": {
-            "description": "The app to launch. Needs to be set if a new or ephemeral session should be launched. For an existing workspace the last app definition will be used if none is given.",
-            "type": "string"
+            "type": "string",
+            "description": "The app to launch. Needs to be set if a new or ephemeral session should be launched. For an existing workspace the last app definition will be used if none is given."
           },
           "workspaceName": {
-            "description": "The name of the workspace to mount/create. Needs to be set if an existing workspace should be launched.",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the workspace to mount/create. Needs to be set if an existing workspace should be launched."
           },
           "label": {
-            "description": "The label of the workspace to mount/create. If no label is given, a default label will be generated.",
-            "type": "string"
+            "type": "string",
+            "description": "The label of the workspace to mount/create. If no label is given, a default label will be generated."
           },
           "ephemeral": {
-            "description": "If true no workspace will be created for the session.",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "If true no workspace will be created for the session."
           },
           "timeout": {
+            "type": "integer",
             "format": "int32",
-            "description": "Number of minutes to wait for session launch. Default is 3 Minutes.",
-            "type": "integer"
+            "description": "Number of minutes to wait for session launch. Default is 3 Minutes."
           },
           "env": {
-            "description": "Environment variables",
+            "$ref": "#/components/schemas/EnvironmentVars",
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EnvironmentVars"
-              }
-            ]
+            "description": "Environment variables"
+          }
+        }
+      },
+      "ManagedFieldsEntry": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "fieldsType": {
+            "type": "string"
+          },
+          "fieldsV1": {
+            "$ref": "#/components/schemas/FieldsV1"
+          },
+          "manager": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "subresource": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
           }
         }
       },
@@ -647,90 +289,180 @@
         "type": "object",
         "properties": {
           "port": {
-            "format": "int32",
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "activityTracker": {
             "$ref": "#/components/schemas/ActivityTracker"
           }
         }
       },
-      "PingRequest": {
-        "description": "Request to ping the availability of the service.",
-        "required": ["appId"],
+      "ObjectMeta": {
         "type": "object",
         "properties": {
-          "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "creationTimestamp": {
             "type": "string"
+          },
+          "deletionGracePeriodSeconds": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletionTimestamp": {
+            "type": "string"
+          },
+          "finalizers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "generateName": {
+            "type": "string"
+          },
+          "generation": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "managedFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ManagedFieldsEntry"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "ownerReferences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OwnerReference"
+            }
+          },
+          "resourceVersion": {
+            "type": "string"
+          },
+          "selfLink": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        }
+      },
+      "OwnerReference": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "blockOwnerDeletion": {
+            "type": "boolean"
+          },
+          "controller": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        }
+      },
+      "PingRequest": {
+        "type": "object",
+        "required": ["appId"],
+        "description": "Request to ping the availability of the service.",
+        "properties": {
+          "appId": {
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           }
         }
       },
       "SessionActivityRequest": {
-        "description": "A request to report activity for a running session.",
-        "required": ["appId", "sessionName"],
         "type": "object",
+        "required": ["appId", "sessionName"],
+        "description": "A request to report activity for a running session.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "sessionName": {
-            "description": "The name of the session for which activity is reported.",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the session for which activity is reported."
           }
         }
       },
       "SessionListRequest": {
-        "description": "A request to list the sessions of a user.",
-        "required": ["appId", "user"],
         "type": "object",
+        "required": ["appId", "user"],
+        "description": "A request to list the sessions of a user.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           }
         }
       },
       "SessionPerformance": {
-        "description": "Description of the performance of a session",
-        "required": ["cpuAmount", "cpuFormat", "memoryAmount", "memoryFormat"],
         "type": "object",
+        "required": ["cpuAmount", "cpuFormat", "memoryAmount", "memoryFormat"],
+        "description": "Description of the performance of a session",
         "properties": {
           "cpuAmount": {
-            "description": "Used CPU amount of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "Used CPU amount of the workspace"
           },
           "cpuFormat": {
-            "description": "Used CPU format of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "Used CPU format of the workspace"
           },
           "memoryAmount": {
-            "description": "Used memory amount of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "Used memory amount of the workspace"
           },
           "memoryFormat": {
-            "description": "Used memory format of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "Used memory format of the workspace"
           }
         }
       },
       "SessionPerformanceRequest": {
-        "description": "A request to list the sessions of a user.",
-        "required": ["appId", "sessionName"],
         "type": "object",
+        "required": ["appId", "sessionName"],
+        "description": "A request to list the sessions of a user.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "sessionName": {
-            "description": "The name of the session",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the session"
           }
         }
       },
@@ -779,142 +511,138 @@
         }
       },
       "SessionStartRequest": {
-        "description": "A request to start a session",
-        "required": ["appId", "user", "appDefinition"],
         "type": "object",
+        "required": ["appId", "user", "appDefinition"],
+        "description": "A request to start a session",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "appDefinition": {
-            "description": "The app to launch.",
-            "type": "string"
+            "type": "string",
+            "description": "The app to launch."
           },
           "workspaceName": {
-            "description": "The name of the workspace to mount/create.",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the workspace to mount/create."
           },
           "timeout": {
+            "type": "integer",
             "format": "int32",
-            "description": "Number of minutes to wait for session launch. Default is 3 Minutes.",
-            "type": "integer"
+            "description": "Number of minutes to wait for session launch. Default is 3 Minutes."
           },
           "env": {
-            "description": "Environment variables",
+            "$ref": "#/components/schemas/EnvironmentVars",
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EnvironmentVars"
-              }
-            ]
+            "description": "Environment variables"
           }
         }
       },
       "SessionStopRequest": {
-        "description": "A request to stop a session",
-        "required": ["appId", "user", "sessionName"],
         "type": "object",
+        "required": ["appId", "user", "sessionName"],
+        "description": "A request to stop a session",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "sessionName": {
-            "description": "The name of the session to stop.",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the session to stop."
           }
         }
       },
       "UserWorkspace": {
-        "description": "Description of a user workspace",
-        "required": ["name", "label", "user", "active"],
         "type": "object",
+        "required": ["name", "label", "user", "active"],
+        "description": "Description of a user workspace",
         "properties": {
           "name": {
-            "description": "The name of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the workspace"
           },
           "label": {
-            "description": "The label of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "The label of the workspace"
           },
           "appDefinition": {
-            "description": "The app this workspace was used with.",
-            "type": "string"
+            "type": "string",
+            "description": "The app this workspace was used with."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "active": {
-            "description": "Whether the workspace is in use at the moment.",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the workspace is in use at the moment."
           }
         }
       },
       "WorkspaceCreationRequest": {
-        "description": "Request to create a new workspace.",
-        "required": ["appId", "user"],
         "type": "object",
+        "required": ["appId", "user"],
+        "description": "Request to create a new workspace.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "appDefinition": {
-            "description": "The app this workspace will be used with.",
-            "type": "string"
+            "type": "string",
+            "description": "The app this workspace will be used with."
           },
           "label": {
-            "description": "The label of the workspace",
-            "type": "string"
+            "type": "string",
+            "description": "The label of the workspace"
           }
         }
       },
       "WorkspaceDeletionRequest": {
-        "description": "Request to delete a workspace",
-        "required": ["appId", "user", "workspaceName"],
         "type": "object",
+        "required": ["appId", "user", "workspaceName"],
+        "description": "Request to delete a workspace",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           },
           "workspaceName": {
-            "description": "The name of the workspace to delete.",
-            "type": "string"
+            "type": "string",
+            "description": "The name of the workspace to delete."
           }
         }
       },
       "WorkspaceListRequest": {
-        "description": "Request to list workspaces of a user.",
-        "required": ["appId", "user"],
         "type": "object",
+        "required": ["appId", "user"],
+        "description": "Request to list workspaces of a user.",
         "properties": {
           "appId": {
-            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied.",
-            "type": "string"
+            "type": "string",
+            "description": "The App Id of this Theia Cloud instance. Request without a matching Id will be denied."
           },
           "user": {
-            "description": "The user identification, usually the email address.",
-            "type": "string"
+            "type": "string",
+            "description": "The user identification, usually the email address."
           }
         }
       }
@@ -926,6 +654,548 @@
         "flows": {
           "implicit": {}
         }
+      }
+    }
+  },
+  "info": {
+    "title": "Theia Cloud API",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/service": {
+      "post": {
+        "summary": "Launch Session",
+        "description": "Launches a session and creates a workspace if required. Responds with the URL of the launched session.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LaunchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Root Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/admin/appdefinition/{appDefinitionName}": {
+      "patch": {
+        "summary": "Updates an app definition",
+        "description": "Updates an app definition's properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.",
+        "parameters": [
+          {
+            "description": "The K8S resource name of the app definition to update.",
+            "name": "appDefinitionName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppDefinitionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppDefinition"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["App Definition Admin Resource"]
+      }
+    },
+    "/service/admin/{appId}": {
+      "get": {
+        "summary": "Admin Ping",
+        "description": "Replies with success if the service is available and the user an admin.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Root Admin Resource"]
+      }
+    },
+    "/service/appdefinition/{appId}": {
+      "get": {
+        "summary": "List app definitions",
+        "description": "List available app definitions.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AppDefinitionSpec"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["App Definition Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/session": {
+      "delete": {
+        "summary": "Stop session",
+        "description": "Stops a session.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionStopRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Session Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Start a new session",
+        "description": "Starts a new session for an existing workspace and responds with the URL of the started session.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionStartRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Session Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      },
+      "patch": {
+        "summary": "Report session activity",
+        "description": "Updates the last activity timestamp for a session to monitor activity.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Session Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/session/performance/{appId}/{sessionName}": {
+      "get": {
+        "summary": "Get performance metrics",
+        "description": "Returns the current CPU and memory usage of the session's pod.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sessionName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionPerformance"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Session Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/session/{appId}/{user}": {
+      "get": {
+        "summary": "List sessions",
+        "description": "List sessions of a user.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SessionSpec"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Session Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/workspace": {
+      "delete": {
+        "summary": "Delete workspace",
+        "description": "Deletes a workspace.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Workspace Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create workspace",
+        "description": "Creates a new workspace for a user.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserWorkspace"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Workspace Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/workspace/{appId}/{user}": {
+      "get": {
+        "summary": "List workspaces",
+        "description": "Lists the workspaces of a user.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserWorkspace"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Workspace Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
+    "/service/{appId}": {
+      "get": {
+        "summary": "Ping",
+        "description": "Replies if the service is available.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "tags": ["Root Resource"],
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
       }
     }
   }

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/AppDefinitionSpec.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/AppDefinitionSpec.java
@@ -164,8 +164,16 @@ public class AppDefinitionSpec {
         return minInstances;
     }
 
+    public void setMinInstances(int minInstances) {
+        this.minInstances = minInstances;
+    }
+
     public Integer getMaxInstances() {
         return maxInstances;
+    }
+
+    public void setMaxInstances(Integer maxInstances) {
+        this.maxInstances = maxInstances;
     }
 
     public Integer getTimeout() {

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnly.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnly.java
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import jakarta.ws.rs.NameBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+
+/**
+ * <p>
+ * Annotation to mark a resource or method as only accessible to admin users.
+ * </p>
+ * <p>
+ * Can be applied to a method or a resource class. In the latter case, the behavior applies to all its methods.
+ * </p>
+ * 
+ * @see AdminOnlyFilter
+ * @see TheiaCloudUserProducer
+ */
+@Inherited
+@NameBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface AdminOnly {
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnlyFilter.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnlyFilter.java
@@ -42,8 +42,8 @@ public class AdminOnlyFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) {
         if (!theiaCloudUser.isAdmin()) {
-            logger.infov("Blocked access to {0} {1} for non-admin user.", requestContext.getMethod(),
-                    requestContext.getUriInfo().getPath());
+            logger.infov("Blocked access to {0} {1} for non-admin user: {2}", requestContext.getMethod(),
+                    requestContext.getUriInfo().getPath(), theiaCloudUser.getIdentifier());
             requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
                     .entity("Admin privileges required to access this resource.").build());
         }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnlyFilter.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/AdminOnlyFilter.java
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * ContainerRequestFilter aborting all requests from non admin users to resources annotated with {@link AdminOnly}.
+ */
+@Provider
+@AdminOnly
+@Priority(Priorities.AUTHORIZATION)
+public class AdminOnlyFilter implements ContainerRequestFilter {
+
+    @Inject
+    Logger logger;
+
+    @Inject
+    TheiaCloudUser theiaCloudUser;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (!theiaCloudUser.isAdmin()) {
+            logger.infov("Blocked access to {0} {1} for non-admin user.", requestContext.getMethod(),
+                    requestContext.getUriInfo().getPath());
+            requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
+                    .entity("Admin privileges required to access this resource.").build());
+        }
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/ApplicationProperties.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/ApplicationProperties.java
@@ -27,15 +27,20 @@ public class ApplicationProperties {
 
     private static final String THEIACLOUD_APP_ID = "theia.cloud.app.id";
     private static final String THEIACLOUD_USE_KEYCLOAK = "theia.cloud.use.keycloak";
+    private static final String THEIACLOUD_ADMIN_GROUP_NAME = "theia.cloud.auth.admin.group";
+
+    private static final String DEFAULT_ADMIN_GROUP_NAME = "theia-cloud/admin";
 
     private final Logger logger;
 
     private final boolean useKeycloak;
     private final String appId;
+    private final String adminGroupName;
 
     public ApplicationProperties() {
         logger = Logger.getLogger(getClass());
         appId = System.getProperty(THEIACLOUD_APP_ID, "asdfghjkl");
+        adminGroupName = System.getProperty(THEIACLOUD_ADMIN_GROUP_NAME, DEFAULT_ADMIN_GROUP_NAME);
         // Only disable keycloak if the value was explicitly set to exactly "false".
         useKeycloak = !"false".equals(System.getProperty(THEIACLOUD_USE_KEYCLOAK));
         if (!useKeycloak) {
@@ -55,5 +60,12 @@ public class ApplicationProperties {
      */
     public boolean isUseKeycloak() {
         return useKeycloak;
+    }
+
+    /**
+     * @return the group name that identifies admin users in the MicroProfile JWT token's groups claim
+     */
+    public String getAdminGroupName() {
+        return adminGroupName;
     }
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
@@ -39,6 +39,7 @@ public class BaseResource {
         logger = Logger.getLogger(getClass().getSuperclass());
     }
 
+    /** @return The correlation id for this request. */
     protected String evaluateRequest(ServiceRequest request) {
         return basicEvaluateRequest(request);
     }
@@ -81,7 +82,7 @@ public class BaseResource {
         // (this might change if the concept of admin users is introduced later)
         if (theiaCloudUser.isAnonymous()) {
             info(correlationId,
-                    "User is unexpectetly considered anonymous and, thus, must not access user scoped resources.");
+                    "User is unexpectedly considered anonymous and, thus, must not access user scoped resources.");
             throw new TheiaCloudWebException(Status.UNAUTHORIZED);
         } else if (request.user == null || request.user.equals(theiaCloudUser.getIdentifier())) {
             return new EvaluatedRequest(correlationId, theiaCloudUser.getIdentifier());

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/K8sUtil.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/K8sUtil.java
@@ -22,6 +22,7 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.eclipse.theia.cloud.common.k8s.client.DefaultTheiaCloudClient;
@@ -224,6 +225,11 @@ public final class K8sUtil {
 
     public boolean hasAppDefinition(String appDefinition) {
         return CLIENT.appDefinitions().get(appDefinition).isPresent();
+    }
+
+    public AppDefinition editAppDefinition(String correlationId, String appDefinition,
+            Consumer<AppDefinition> consumer) {
+        return CLIENT.appDefinitions().edit(correlationId, appDefinition, consumer);
     }
 
     public boolean isMaxInstancesReached(String appDefString) {

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudUser.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudUser.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022-2023 EclipseSource, STMicroelectronics and others.
+ * Copyright (C) 2022-2025 EclipseSource, STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,12 +22,29 @@ import java.util.Objects;
  */
 public class TheiaCloudUser {
 
-    public static TheiaCloudUser ANONYMOUS = new TheiaCloudUser(null);
+    public static final TheiaCloudUser ANONYMOUS = new TheiaCloudUser(null, false);
 
-    private String identifier;
+    private final String identifier;
+    private final boolean admin;
 
+    /**
+     * Creates a non-admin user.
+     *
+     * @param identifier the user identifier
+     */
     public TheiaCloudUser(String identifier) {
+        this(identifier, false);
+    }
+
+    /**
+     * Creates a user with the specified admin flag.
+     *
+     * @param identifier the user identifier
+     * @param admin      {@code true} if the user is an admin
+     */
+    public TheiaCloudUser(String identifier, boolean admin) {
         this.identifier = identifier;
+        this.admin = admin;
     }
 
     /**
@@ -41,13 +58,27 @@ public class TheiaCloudUser {
         return identifier;
     }
 
+    /**
+     * Returns whether the user is an admin.
+     *
+     * @return {@code true} if admin and not anonymous, {@code false} otherwise
+     */
+    public boolean isAdmin() {
+        return !isAnonymous() && admin;
+    }
+
+    /**
+     * Determines if the user is anonymous.
+     *
+     * @return {@code true} if the user is anonymous
+     */
     public boolean isAnonymous() {
         return identifier == null || identifier.isBlank();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier);
+        return Objects.hash(identifier, admin);
     }
 
     @Override
@@ -59,12 +90,11 @@ public class TheiaCloudUser {
         if (getClass() != obj.getClass())
             return false;
         TheiaCloudUser other = (TheiaCloudUser) obj;
-        return Objects.equals(identifier, other.identifier);
+        return Objects.equals(identifier, other.identifier) && admin == other.admin;
     }
 
     @Override
     public String toString() {
-        return "TheiaCloudUser [identifier=" + identifier + "]";
+        return "TheiaCloudUser [identifier=" + identifier + ", admin=" + admin + "]";
     }
-
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/RootAdminResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/RootAdminResource.java
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service.admin;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.theia.cloud.service.AdminOnly;
+import org.eclipse.theia.cloud.service.ApplicationProperties;
+import org.eclipse.theia.cloud.service.BaseResource;
+import org.eclipse.theia.cloud.service.PingRequest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/service/admin")
+@AdminOnly
+public class RootAdminResource extends BaseResource {
+
+    @Inject
+    public RootAdminResource(ApplicationProperties applicationProperties) {
+        super(applicationProperties);
+    }
+
+    @Operation(summary = "Admin Ping", description = "Replies with success if the service is available and the user an admin.")
+    @GET
+    @Path("/{appId}")
+    public boolean ping(@PathParam("appId") String appId) {
+        evaluateRequest(new PingRequest(appId));
+        return true;
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionAdminResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionAdminResource.java
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service.admin.appdefinition;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
+import org.eclipse.theia.cloud.service.AdminOnly;
+import org.eclipse.theia.cloud.service.ApplicationProperties;
+import org.eclipse.theia.cloud.service.BaseResource;
+import org.eclipse.theia.cloud.service.K8sUtil;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Resource for admin operations on app definitions.
+ */
+@Path("/service/admin/appdefinition")
+@AdminOnly
+public class AppDefinitionAdminResource extends BaseResource {
+
+    @Inject
+    private K8sUtil k8sUtil;
+
+    @Inject
+    public AppDefinitionAdminResource(ApplicationProperties applicationProperties) {
+        super(applicationProperties);
+    }
+
+    @Operation(summary = "Updates an app definition", description = "Updates an app definition's properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.")
+    @Parameter(name = "appDefinitionName", description = "The K8S resource name of the app definition to update.")
+    @PATCH
+    @Path("/{appDefinitionName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public AppDefinition update(@PathParam("appDefinitionName") String appDefinitionName,
+            AppDefinitionUpdateRequest request) {
+        String correlationId = evaluateRequest(request);
+        if (!k8sUtil.hasAppDefinition(appDefinitionName)) {
+            throw new NotFoundException("App definition does not exist.");
+        }
+
+        info(correlationId, "Update app definition " + request);
+        try {
+            return k8sUtil.editAppDefinition(correlationId, appDefinitionName, appDef -> {
+                AppDefinitionSpec spec = appDef.getSpec();
+                if (request.minInstances != null) {
+                    spec.setMinInstances(request.minInstances);
+                }
+                if (request.maxInstances != null) {
+                    spec.setMaxInstances(request.maxInstances);
+                }
+            });
+        } catch (Exception e) {
+            error(correlationId, "Failed to update app definition ", e);
+            throw new InternalServerErrorException(
+                    "Failed to update app definition. See the service logs for more details.");
+        }
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionUpdateRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionUpdateRequest.java
@@ -1,3 +1,18 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
 package org.eclipse.theia.cloud.service.admin.appdefinition;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -18,5 +33,11 @@ public class AppDefinitionUpdateRequest extends ServiceRequest {
 
     public AppDefinitionUpdateRequest(String appId) {
         super(KIND, appId);
+    }
+
+    @Override
+    public String toString() {
+        return "AppDefinitionUpdateRequest [minInstances=" + minInstances + ", maxInstances=" + maxInstances
+                + ", appId=" + appId + ", kind=" + kind + "]";
     }
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionUpdateRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionUpdateRequest.java
@@ -1,0 +1,22 @@
+package org.eclipse.theia.cloud.service.admin.appdefinition;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.theia.cloud.service.ServiceRequest;
+
+public class AppDefinitionUpdateRequest extends ServiceRequest {
+    public static final String KIND = "appDefinitionUpdateRequest";
+
+    @Schema(description = "The minimum number of instances to run.", required = false)
+    public Integer minInstances;
+
+    @Schema(description = "The maximum number of instances to run.", required = false)
+    public Integer maxInstances;
+
+    public AppDefinitionUpdateRequest() {
+        super(KIND);
+    }
+
+    public AppDefinitionUpdateRequest(String appId) {
+        super(KIND, appId);
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/AdminOnlyFilterTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/AdminOnlyFilterTests.java
@@ -1,0 +1,110 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class AdminOnlyFilterTests {
+
+    @Mock
+    ContainerRequestContext requestContext;
+
+    @Mock
+    UriInfo uriInfo;
+
+    @Mock
+    Logger logger;
+
+    @InjectMock
+    TheiaCloudUser theiaCloudUser;
+
+    @Inject
+    AdminOnlyFilter fixture;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Initialize mocks created above
+        MockitoAnnotations.openMocks(this);
+
+        // Manually inject the logger into the filter because using @InjectMock leads to an error in LoggerProducer.
+        fixture.logger = logger;
+
+        // Mock method and URI info
+        when(requestContext.getMethod()).thenReturn("GET");
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("test/path");
+    }
+
+    /**
+     * Verifies that when an admin user is injected into the filter, the filter does not abort the request.
+     */
+    @Test
+    void intercept_adminUser_proceed() throws Exception {
+        // Configure Theia Cloud user as admin.
+        when(theiaCloudUser.isAdmin()).thenReturn(true);
+
+        // Run the filter.
+        fixture.filter(requestContext);
+
+        // Verify that abortWith was never called.
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    /**
+     * Verifies that when a non-admin user is injected into the filter, the filter aborts the request with a 403
+     * Forbidden status.
+     */
+    @Test
+    void intercept_nonAdminUser_throwForbidden() throws Exception {
+        // Configure Theia Cloud user as non-admin.
+        when(theiaCloudUser.isAdmin()).thenReturn(false);
+
+        // Run the filter.
+        fixture.filter(requestContext);
+
+        // Capture the Response passed to abortWith.
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        Response response = responseCaptor.getValue();
+
+        // Verify that the response has status 403 and contains the expected error message.
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+        assertEquals("Admin privileges required to access this resource.", response.getEntity());
+        /// Verify something was logged
+        verify(logger).infov(anyString(), anyString(), anyString());
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/AdminOnlyFilterTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/AdminOnlyFilterTests.java
@@ -18,6 +18,7 @@ package org.eclipse.theia.cloud.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -92,6 +93,7 @@ public class AdminOnlyFilterTests {
     void intercept_nonAdminUser_throwForbidden() throws Exception {
         // Configure Theia Cloud user as non-admin.
         when(theiaCloudUser.isAdmin()).thenReturn(false);
+        when(theiaCloudUser.getIdentifier()).thenReturn("test-user");
 
         // Run the filter.
         fixture.filter(requestContext);
@@ -105,6 +107,6 @@ public class AdminOnlyFilterTests {
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
         assertEquals("Admin privileges required to access this resource.", response.getEntity());
         /// Verify something was logged
-        verify(logger).infov(anyString(), anyString(), anyString());
+        verify(logger).infov(anyString(), anyString(), anyString(), eq("test-user"));
     }
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/ApplicationPropertiesTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/ApplicationPropertiesTests.java
@@ -15,6 +15,7 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,5 +54,19 @@ class ApplicationPropertiesTests {
         System.setProperty(THEIACLOUD_USE_KEYCLOAK, "asdasd");
         ApplicationProperties fixture = new ApplicationProperties();
         assertTrue(fixture.isUseKeycloak());
+    }
+
+    @Test
+    void getAdminGroupName_propertyNotSet_returnDefault() {
+        System.clearProperty("theia.cloud.auth.admin.group");
+        ApplicationProperties fixture = new ApplicationProperties();
+        assertEquals("theia-cloud/admin", fixture.getAdminGroupName());
+    }
+
+    @Test
+    void getAdminGroupName_propertySet_returnValue() {
+        System.setProperty("theia.cloud.auth.admin.group", "test-admin-group");
+        ApplicationProperties fixture = new ApplicationProperties();
+        assertEquals("test-admin-group", fixture.getAdminGroupName());
     }
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionAdminResourceTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/admin/appdefinition/AppDefinitionAdminResourceTests.java
@@ -1,0 +1,177 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service.admin.appdefinition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.InternalServerErrorException;
+
+import java.util.function.Consumer;
+
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
+import org.eclipse.theia.cloud.service.ApplicationProperties;
+import org.eclipse.theia.cloud.service.K8sUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+
+/**
+ * Unit tests for {@link AppDefinitionAdminResource}. Disable authorization via {@link TestSecurity} annotation as this
+ * is a unit test of the resource itself. Thus, we do not want authentication interceptors to trigger when calling the
+ * resource's methods.
+ */
+@QuarkusTest
+@TestSecurity(authorizationEnabled = false)
+public class AppDefinitionAdminResourceTests {
+
+    private static final String APP_ID = "asdfghjkl";
+
+    @InjectMock
+    ApplicationProperties applicationProperties;
+
+    @InjectMock
+    K8sUtil k8sUtil;
+
+    @Inject
+    AppDefinitionAdminResource fixture;
+
+    @BeforeEach
+    public void setUp() {
+        Mockito.when(applicationProperties.getAppId()).thenReturn(APP_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdate_validAppDefinition_returnsUpdatedDefinition() {
+        final String appDefinitionName = "testApp";
+        AppDefinitionUpdateRequest request = new AppDefinitionUpdateRequest(APP_ID);
+        request.minInstances = 1;
+        request.maxInstances = 5;
+
+        Mockito.when(k8sUtil.hasAppDefinition(appDefinitionName)).thenReturn(true);
+        Mockito.when(k8sUtil.editAppDefinition(anyString(), eq(appDefinitionName), any(Consumer.class)))
+                .thenAnswer(invocation -> {
+                    Consumer<AppDefinition> consumer = invocation.getArgument(2);
+                    // Create an anonymous AppDefinition implementation using production AppDefinitionSpec.
+                    AppDefinition appDef = Mockito.mock(AppDefinition.class);
+                    AppDefinitionSpec appDefSpec = new AppDefinitionSpec();
+                    Mockito.when(appDef.getSpec()).thenReturn(appDefSpec);
+                    consumer.accept(appDef);
+                    return appDef;
+                });
+
+        AppDefinition result = fixture.update(appDefinitionName, request);
+        AppDefinitionSpec resultSpec = result.getSpec();
+        assertEquals(1, resultSpec.getMinInstances());
+        assertEquals(5, resultSpec.getMaxInstances());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdate_validAppDefinitionNullMaxInstances_returnsUpdatedDefinition() {
+        final String appDefinitionName = "testApp";
+        AppDefinitionUpdateRequest request = new AppDefinitionUpdateRequest(APP_ID);
+        request.minInstances = 1;
+        request.maxInstances = null;
+        AppDefinitionSpec appDefSpec = new AppDefinitionSpec();
+        appDefSpec.setMaxInstances(10);
+
+        Mockito.when(k8sUtil.hasAppDefinition(appDefinitionName)).thenReturn(true);
+        Mockito.when(k8sUtil.editAppDefinition(anyString(), eq(appDefinitionName), any(Consumer.class)))
+                .thenAnswer(invocation -> {
+                    Consumer<AppDefinition> consumer = invocation.getArgument(2);
+                    // Create an anonymous AppDefinition implementation using production AppDefinitionSpec.
+                    AppDefinition appDef = Mockito.mock(AppDefinition.class);
+                    Mockito.when(appDef.getSpec()).thenReturn(appDefSpec);
+                    consumer.accept(appDef);
+                    return appDef;
+                });
+
+        AppDefinition result = fixture.update(appDefinitionName, request);
+        AppDefinitionSpec resultSpec = result.getSpec();
+        assertEquals(1, resultSpec.getMinInstances());
+        // For a null parameter, the value should not be changed.
+        assertEquals(10, resultSpec.getMaxInstances());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdate_validAppDefinitionNullMinInstances_returnsUpdatedDefinition() {
+        final String appDefinitionName = "testApp";
+        AppDefinitionUpdateRequest request = new AppDefinitionUpdateRequest(APP_ID);
+        request.minInstances = null;
+        request.maxInstances = 5;
+        AppDefinitionSpec appDefSpec = new AppDefinitionSpec();
+        appDefSpec.setMinInstances(1);
+
+        Mockito.when(k8sUtil.hasAppDefinition(appDefinitionName)).thenReturn(true);
+        Mockito.when(k8sUtil.editAppDefinition(anyString(), eq(appDefinitionName), any(Consumer.class)))
+                .thenAnswer(invocation -> {
+                    Consumer<AppDefinition> consumer = invocation.getArgument(2);
+                    // Create an anonymous AppDefinition implementation using production AppDefinitionSpec.
+                    AppDefinition appDef = Mockito.mock(AppDefinition.class);
+                    Mockito.when(appDef.getSpec()).thenReturn(appDefSpec);
+                    consumer.accept(appDef);
+                    return appDef;
+                });
+
+        AppDefinition result = fixture.update(appDefinitionName, request);
+        AppDefinitionSpec resultSpec = result.getSpec();
+        // For a null parameter, the value should not be changed.
+        assertEquals(1, resultSpec.getMinInstances());
+        assertEquals(5, resultSpec.getMaxInstances());
+    }
+
+    @Test
+    public void testUpdate_appDefinitionNotFound_throwsNotFoundException() {
+        String appDefinitionName = "nonexistent";
+        AppDefinitionUpdateRequest request = new AppDefinitionUpdateRequest(APP_ID);
+
+        Mockito.when(k8sUtil.hasAppDefinition(appDefinitionName)).thenReturn(false);
+
+        assertThrows(NotFoundException.class, () -> {
+            fixture.update(appDefinitionName, request);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdate_editAppDefinitionThrows_internalServerErrorException() {
+        String appDefinitionName = "testApp";
+        AppDefinitionUpdateRequest request = new AppDefinitionUpdateRequest(APP_ID);
+        request.minInstances = 2;
+        request.maxInstances = 10;
+
+        Mockito.when(k8sUtil.hasAppDefinition(appDefinitionName)).thenReturn(true);
+        Mockito.when(k8sUtil.editAppDefinition(anyString(), eq(appDefinitionName), any(Consumer.class)))
+                .thenThrow(new RuntimeException("Edit failure"));
+
+        assertThrows(InternalServerErrorException.class, () -> {
+            fixture.update(appDefinitionName, request);
+        });
+    }
+}

--- a/node/common/src/client/api.ts
+++ b/node/common/src/client/api.ts
@@ -43,6 +43,91 @@ export interface ActivityTracker {
     'notifyAfter'?: number;
 }
 /**
+ * 
+ * @export
+ * @interface AppDefinition
+ */
+export interface AppDefinition {
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'apiVersion'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'kind'?: string;
+    /**
+     * 
+     * @type {ObjectMeta}
+     * @memberof AppDefinition
+     */
+    'metadata'?: ObjectMeta;
+    /**
+     * 
+     * @type {AppDefinitionSpec}
+     * @memberof AppDefinition
+     */
+    'spec'?: AppDefinitionSpec;
+    /**
+     * 
+     * @type {AppDefinitionStatus}
+     * @memberof AppDefinition
+     */
+    'status'?: AppDefinitionStatus;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'singular'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'crdName'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'scope'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'plural'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AppDefinition
+     */
+    'served'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AppDefinition
+     */
+    'storage'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AppDefinition
+     */
+    'deprecated'?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinition
+     */
+    'deprecationWarning'?: string;
+}
+/**
  * A request to list available app definitions.
  * @export
  * @interface AppDefinitionListRequest
@@ -183,6 +268,50 @@ export interface AppDefinitionSpec {
     'ingressHostnamePrefixes'?: Array<string>;
 }
 /**
+ * 
+ * @export
+ * @interface AppDefinitionStatus
+ */
+export interface AppDefinitionStatus {
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinitionStatus
+     */
+    'operatorStatus'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AppDefinitionStatus
+     */
+    'operatorMessage'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface AppDefinitionUpdateRequest
+ */
+export interface AppDefinitionUpdateRequest {
+    /**
+     * The App Id of this Theia Cloud instance. Request without a matching Id will be denied.
+     * @type {string}
+     * @memberof AppDefinitionUpdateRequest
+     */
+    'appId': string;
+    /**
+     * The minimum number of instances to run.
+     * @type {number}
+     * @memberof AppDefinitionUpdateRequest
+     */
+    'minInstances'?: number;
+    /**
+     * The maximum number of instances to run.
+     * @type {number}
+     * @memberof AppDefinitionUpdateRequest
+     */
+    'maxInstances'?: number;
+}
+/**
  * An object to hold all the ways environment variables can be passed. Not to be used by itself.
  * @export
  * @interface EnvironmentVars
@@ -265,6 +394,55 @@ export interface LaunchRequest {
 /**
  * 
  * @export
+ * @interface ManagedFieldsEntry
+ */
+export interface ManagedFieldsEntry {
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'apiVersion'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'fieldsType'?: string;
+    /**
+     * 
+     * @type {object}
+     * @memberof ManagedFieldsEntry
+     */
+    'fieldsV1'?: object;
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'manager'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'operation'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'subresource'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ManagedFieldsEntry
+     */
+    'time'?: string;
+}
+/**
+ * 
+ * @export
  * @interface Monitor
  */
 export interface Monitor {
@@ -280,6 +458,146 @@ export interface Monitor {
      * @memberof Monitor
      */
     'activityTracker'?: ActivityTracker;
+}
+/**
+ * 
+ * @export
+ * @interface ObjectMeta
+ */
+export interface ObjectMeta {
+    /**
+     * 
+     * @type {{ [key: string]: string; }}
+     * @memberof ObjectMeta
+     */
+    'annotations'?: { [key: string]: string; };
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'creationTimestamp'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof ObjectMeta
+     */
+    'deletionGracePeriodSeconds'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'deletionTimestamp'?: string;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof ObjectMeta
+     */
+    'finalizers'?: Array<string>;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'generateName'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof ObjectMeta
+     */
+    'generation'?: number;
+    /**
+     * 
+     * @type {{ [key: string]: string; }}
+     * @memberof ObjectMeta
+     */
+    'labels'?: { [key: string]: string; };
+    /**
+     * 
+     * @type {Array<ManagedFieldsEntry>}
+     * @memberof ObjectMeta
+     */
+    'managedFields'?: Array<ManagedFieldsEntry>;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'namespace'?: string;
+    /**
+     * 
+     * @type {Array<OwnerReference>}
+     * @memberof ObjectMeta
+     */
+    'ownerReferences'?: Array<OwnerReference>;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'resourceVersion'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'selfLink'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ObjectMeta
+     */
+    'uid'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface OwnerReference
+ */
+export interface OwnerReference {
+    /**
+     * 
+     * @type {string}
+     * @memberof OwnerReference
+     */
+    'apiVersion'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof OwnerReference
+     */
+    'kind'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof OwnerReference
+     */
+    'blockOwnerDeletion'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof OwnerReference
+     */
+    'controller'?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof OwnerReference
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof OwnerReference
+     */
+    'uid'?: string;
 }
 /**
  * Request to ping the availability of the service.
@@ -625,6 +943,123 @@ export interface WorkspaceListRequest {
 }
 
 /**
+ * AppDefinitionAdminResourceApi - axios parameter creator
+ * @export
+ */
+export const AppDefinitionAdminResourceApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Updates an app definition\'s properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.
+         * @summary Updates an app definition
+         * @param {string} appDefinitionName The K8S resource name of the app definition to update.
+         * @param {AppDefinitionUpdateRequest} appDefinitionUpdateRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceAdminAppdefinitionAppDefinitionNamePatch: async (appDefinitionName: string, appDefinitionUpdateRequest: AppDefinitionUpdateRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'appDefinitionName' is not null or undefined
+            assertParamExists('serviceAdminAppdefinitionAppDefinitionNamePatch', 'appDefinitionName', appDefinitionName)
+            // verify required parameter 'appDefinitionUpdateRequest' is not null or undefined
+            assertParamExists('serviceAdminAppdefinitionAppDefinitionNamePatch', 'appDefinitionUpdateRequest', appDefinitionUpdateRequest)
+            const localVarPath = `/service/admin/appdefinition/{appDefinitionName}`
+                .replace(`{${"appDefinitionName"}}`, encodeURIComponent(String(appDefinitionName)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(appDefinitionUpdateRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * AppDefinitionAdminResourceApi - functional programming interface
+ * @export
+ */
+export const AppDefinitionAdminResourceApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = AppDefinitionAdminResourceApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Updates an app definition\'s properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.
+         * @summary Updates an app definition
+         * @param {string} appDefinitionName The K8S resource name of the app definition to update.
+         * @param {AppDefinitionUpdateRequest} appDefinitionUpdateRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName: string, appDefinitionUpdateRequest: AppDefinitionUpdateRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AppDefinition>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName, appDefinitionUpdateRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AppDefinitionAdminResourceApi.serviceAdminAppdefinitionAppDefinitionNamePatch']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * AppDefinitionAdminResourceApi - factory interface
+ * @export
+ */
+export const AppDefinitionAdminResourceApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = AppDefinitionAdminResourceApiFp(configuration)
+    return {
+        /**
+         * Updates an app definition\'s properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.
+         * @summary Updates an app definition
+         * @param {string} appDefinitionName The K8S resource name of the app definition to update.
+         * @param {AppDefinitionUpdateRequest} appDefinitionUpdateRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName: string, appDefinitionUpdateRequest: AppDefinitionUpdateRequest, options?: RawAxiosRequestConfig): AxiosPromise<AppDefinition> {
+            return localVarFp.serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName, appDefinitionUpdateRequest, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * AppDefinitionAdminResourceApi - object-oriented interface
+ * @export
+ * @class AppDefinitionAdminResourceApi
+ * @extends {BaseAPI}
+ */
+export class AppDefinitionAdminResourceApi extends BaseAPI {
+    /**
+     * Updates an app definition\'s properties. Allowed properties to update are defined by AppDefinitionUpdateRequest.
+     * @summary Updates an app definition
+     * @param {string} appDefinitionName The K8S resource name of the app definition to update.
+     * @param {AppDefinitionUpdateRequest} appDefinitionUpdateRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AppDefinitionAdminResourceApi
+     */
+    public serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName: string, appDefinitionUpdateRequest: AppDefinitionUpdateRequest, options?: RawAxiosRequestConfig) {
+        return AppDefinitionAdminResourceApiFp(this.configuration).serviceAdminAppdefinitionAppDefinitionNamePatch(appDefinitionName, appDefinitionUpdateRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
  * AppDefinitionResourceApi - axios parameter creator
  * @export
  */
@@ -737,6 +1172,114 @@ export class AppDefinitionResourceApi extends BaseAPI {
 
 
 /**
+ * RootAdminResourceApi - axios parameter creator
+ * @export
+ */
+export const RootAdminResourceApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Replies with success if the service is available and the user an admin.
+         * @summary Admin Ping
+         * @param {string} appId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceAdminAppIdGet: async (appId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'appId' is not null or undefined
+            assertParamExists('serviceAdminAppIdGet', 'appId', appId)
+            const localVarPath = `/service/admin/{appId}`
+                .replace(`{${"appId"}}`, encodeURIComponent(String(appId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * RootAdminResourceApi - functional programming interface
+ * @export
+ */
+export const RootAdminResourceApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = RootAdminResourceApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Replies with success if the service is available and the user an admin.
+         * @summary Admin Ping
+         * @param {string} appId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async serviceAdminAppIdGet(appId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.serviceAdminAppIdGet(appId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RootAdminResourceApi.serviceAdminAppIdGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * RootAdminResourceApi - factory interface
+ * @export
+ */
+export const RootAdminResourceApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = RootAdminResourceApiFp(configuration)
+    return {
+        /**
+         * Replies with success if the service is available and the user an admin.
+         * @summary Admin Ping
+         * @param {string} appId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceAdminAppIdGet(appId: string, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
+            return localVarFp.serviceAdminAppIdGet(appId, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * RootAdminResourceApi - object-oriented interface
+ * @export
+ * @class RootAdminResourceApi
+ * @extends {BaseAPI}
+ */
+export class RootAdminResourceApi extends BaseAPI {
+    /**
+     * Replies with success if the service is available and the user an admin.
+     * @summary Admin Ping
+     * @param {string} appId 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RootAdminResourceApi
+     */
+    public serviceAdminAppIdGet(appId: string, options?: RawAxiosRequestConfig) {
+        return RootAdminResourceApiFp(this.configuration).serviceAdminAppIdGet(appId, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
  * RootResourceApi - axios parameter creator
  * @export
  */
@@ -783,11 +1326,13 @@ export const RootResourceApiAxiosParamCreator = function (configuration?: Config
         /**
          * Launches a session and creates a workspace if required. Responds with the URL of the launched session.
          * @summary Launch Session
-         * @param {LaunchRequest} [launchRequest] 
+         * @param {LaunchRequest} launchRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        servicePost: async (launchRequest?: LaunchRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        servicePost: async (launchRequest: LaunchRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'launchRequest' is not null or undefined
+            assertParamExists('servicePost', 'launchRequest', launchRequest)
             const localVarPath = `/service`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -844,11 +1389,11 @@ export const RootResourceApiFp = function(configuration?: Configuration) {
         /**
          * Launches a session and creates a workspace if required. Responds with the URL of the launched session.
          * @summary Launch Session
-         * @param {LaunchRequest} [launchRequest] 
+         * @param {LaunchRequest} launchRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async servicePost(launchRequest?: LaunchRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+        async servicePost(launchRequest: LaunchRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.servicePost(launchRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['RootResourceApi.servicePost']?.[localVarOperationServerIndex]?.url;
@@ -877,11 +1422,11 @@ export const RootResourceApiFactory = function (configuration?: Configuration, b
         /**
          * Launches a session and creates a workspace if required. Responds with the URL of the launched session.
          * @summary Launch Session
-         * @param {LaunchRequest} [launchRequest] 
+         * @param {LaunchRequest} launchRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        servicePost(launchRequest?: LaunchRequest, options?: RawAxiosRequestConfig): AxiosPromise<string> {
+        servicePost(launchRequest: LaunchRequest, options?: RawAxiosRequestConfig): AxiosPromise<string> {
             return localVarFp.servicePost(launchRequest, options).then((request) => request(axios, basePath));
         },
     };
@@ -909,12 +1454,12 @@ export class RootResourceApi extends BaseAPI {
     /**
      * Launches a session and creates a workspace if required. Responds with the URL of the launched session.
      * @summary Launch Session
-     * @param {LaunchRequest} [launchRequest] 
+     * @param {LaunchRequest} launchRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof RootResourceApi
      */
-    public servicePost(launchRequest?: LaunchRequest, options?: RawAxiosRequestConfig) {
+    public servicePost(launchRequest: LaunchRequest, options?: RawAxiosRequestConfig) {
         return RootResourceApiFp(this.configuration).servicePost(launchRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
@@ -972,11 +1517,13 @@ export const SessionResourceApiAxiosParamCreator = function (configuration?: Con
         /**
          * Stops a session.
          * @summary Stop session
-         * @param {SessionStopRequest} [sessionStopRequest] 
+         * @param {SessionStopRequest} sessionStopRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionDelete: async (sessionStopRequest?: SessionStopRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serviceSessionDelete: async (sessionStopRequest: SessionStopRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'sessionStopRequest' is not null or undefined
+            assertParamExists('serviceSessionDelete', 'sessionStopRequest', sessionStopRequest)
             const localVarPath = `/service/session`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1010,11 +1557,13 @@ export const SessionResourceApiAxiosParamCreator = function (configuration?: Con
         /**
          * Updates the last activity timestamp for a session to monitor activity.
          * @summary Report session activity
-         * @param {SessionActivityRequest} [sessionActivityRequest] 
+         * @param {SessionActivityRequest} sessionActivityRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionPatch: async (sessionActivityRequest?: SessionActivityRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serviceSessionPatch: async (sessionActivityRequest: SessionActivityRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'sessionActivityRequest' is not null or undefined
+            assertParamExists('serviceSessionPatch', 'sessionActivityRequest', sessionActivityRequest)
             const localVarPath = `/service/session`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1090,11 +1639,13 @@ export const SessionResourceApiAxiosParamCreator = function (configuration?: Con
         /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
          * @summary Start a new session
-         * @param {SessionStartRequest} [sessionStartRequest] 
+         * @param {SessionStartRequest} sessionStartRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionPost: async (sessionStartRequest?: SessionStartRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serviceSessionPost: async (sessionStartRequest: SessionStartRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'sessionStartRequest' is not null or undefined
+            assertParamExists('serviceSessionPost', 'sessionStartRequest', sessionStartRequest)
             const localVarPath = `/service/session`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1152,11 +1703,11 @@ export const SessionResourceApiFp = function(configuration?: Configuration) {
         /**
          * Stops a session.
          * @summary Stop session
-         * @param {SessionStopRequest} [sessionStopRequest] 
+         * @param {SessionStopRequest} sessionStopRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serviceSessionDelete(sessionStopRequest?: SessionStopRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+        async serviceSessionDelete(sessionStopRequest: SessionStopRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.serviceSessionDelete(sessionStopRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SessionResourceApi.serviceSessionDelete']?.[localVarOperationServerIndex]?.url;
@@ -1165,11 +1716,11 @@ export const SessionResourceApiFp = function(configuration?: Configuration) {
         /**
          * Updates the last activity timestamp for a session to monitor activity.
          * @summary Report session activity
-         * @param {SessionActivityRequest} [sessionActivityRequest] 
+         * @param {SessionActivityRequest} sessionActivityRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serviceSessionPatch(sessionActivityRequest?: SessionActivityRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+        async serviceSessionPatch(sessionActivityRequest: SessionActivityRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.serviceSessionPatch(sessionActivityRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SessionResourceApi.serviceSessionPatch']?.[localVarOperationServerIndex]?.url;
@@ -1192,11 +1743,11 @@ export const SessionResourceApiFp = function(configuration?: Configuration) {
         /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
          * @summary Start a new session
-         * @param {SessionStartRequest} [sessionStartRequest] 
+         * @param {SessionStartRequest} sessionStartRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serviceSessionPost(sessionStartRequest?: SessionStartRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+        async serviceSessionPost(sessionStartRequest: SessionStartRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.serviceSessionPost(sessionStartRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SessionResourceApi.serviceSessionPost']?.[localVarOperationServerIndex]?.url;
@@ -1226,21 +1777,21 @@ export const SessionResourceApiFactory = function (configuration?: Configuration
         /**
          * Stops a session.
          * @summary Stop session
-         * @param {SessionStopRequest} [sessionStopRequest] 
+         * @param {SessionStopRequest} sessionStopRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionDelete(sessionStopRequest?: SessionStopRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
+        serviceSessionDelete(sessionStopRequest: SessionStopRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
             return localVarFp.serviceSessionDelete(sessionStopRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Updates the last activity timestamp for a session to monitor activity.
          * @summary Report session activity
-         * @param {SessionActivityRequest} [sessionActivityRequest] 
+         * @param {SessionActivityRequest} sessionActivityRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionPatch(sessionActivityRequest?: SessionActivityRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
+        serviceSessionPatch(sessionActivityRequest: SessionActivityRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
             return localVarFp.serviceSessionPatch(sessionActivityRequest, options).then((request) => request(axios, basePath));
         },
         /**
@@ -1257,11 +1808,11 @@ export const SessionResourceApiFactory = function (configuration?: Configuration
         /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
          * @summary Start a new session
-         * @param {SessionStartRequest} [sessionStartRequest] 
+         * @param {SessionStartRequest} sessionStartRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceSessionPost(sessionStartRequest?: SessionStartRequest, options?: RawAxiosRequestConfig): AxiosPromise<string> {
+        serviceSessionPost(sessionStartRequest: SessionStartRequest, options?: RawAxiosRequestConfig): AxiosPromise<string> {
             return localVarFp.serviceSessionPost(sessionStartRequest, options).then((request) => request(axios, basePath));
         },
     };
@@ -1290,24 +1841,24 @@ export class SessionResourceApi extends BaseAPI {
     /**
      * Stops a session.
      * @summary Stop session
-     * @param {SessionStopRequest} [sessionStopRequest] 
+     * @param {SessionStopRequest} sessionStopRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SessionResourceApi
      */
-    public serviceSessionDelete(sessionStopRequest?: SessionStopRequest, options?: RawAxiosRequestConfig) {
+    public serviceSessionDelete(sessionStopRequest: SessionStopRequest, options?: RawAxiosRequestConfig) {
         return SessionResourceApiFp(this.configuration).serviceSessionDelete(sessionStopRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Updates the last activity timestamp for a session to monitor activity.
      * @summary Report session activity
-     * @param {SessionActivityRequest} [sessionActivityRequest] 
+     * @param {SessionActivityRequest} sessionActivityRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SessionResourceApi
      */
-    public serviceSessionPatch(sessionActivityRequest?: SessionActivityRequest, options?: RawAxiosRequestConfig) {
+    public serviceSessionPatch(sessionActivityRequest: SessionActivityRequest, options?: RawAxiosRequestConfig) {
         return SessionResourceApiFp(this.configuration).serviceSessionPatch(sessionActivityRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
@@ -1327,12 +1878,12 @@ export class SessionResourceApi extends BaseAPI {
     /**
      * Starts a new session for an existing workspace and responds with the URL of the started session.
      * @summary Start a new session
-     * @param {SessionStartRequest} [sessionStartRequest] 
+     * @param {SessionStartRequest} sessionStartRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SessionResourceApi
      */
-    public serviceSessionPost(sessionStartRequest?: SessionStartRequest, options?: RawAxiosRequestConfig) {
+    public serviceSessionPost(sessionStartRequest: SessionStartRequest, options?: RawAxiosRequestConfig) {
         return SessionResourceApiFp(this.configuration).serviceSessionPost(sessionStartRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
@@ -1390,11 +1941,13 @@ export const WorkspaceResourceApiAxiosParamCreator = function (configuration?: C
         /**
          * Deletes a workspace.
          * @summary Delete workspace
-         * @param {WorkspaceDeletionRequest} [workspaceDeletionRequest] 
+         * @param {WorkspaceDeletionRequest} workspaceDeletionRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceWorkspaceDelete: async (workspaceDeletionRequest?: WorkspaceDeletionRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serviceWorkspaceDelete: async (workspaceDeletionRequest: WorkspaceDeletionRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'workspaceDeletionRequest' is not null or undefined
+            assertParamExists('serviceWorkspaceDelete', 'workspaceDeletionRequest', workspaceDeletionRequest)
             const localVarPath = `/service/workspace`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1428,11 +1981,13 @@ export const WorkspaceResourceApiAxiosParamCreator = function (configuration?: C
         /**
          * Creates a new workspace for a user.
          * @summary Create workspace
-         * @param {WorkspaceCreationRequest} [workspaceCreationRequest] 
+         * @param {WorkspaceCreationRequest} workspaceCreationRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceWorkspacePost: async (workspaceCreationRequest?: WorkspaceCreationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serviceWorkspacePost: async (workspaceCreationRequest: WorkspaceCreationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'workspaceCreationRequest' is not null or undefined
+            assertParamExists('serviceWorkspacePost', 'workspaceCreationRequest', workspaceCreationRequest)
             const localVarPath = `/service/workspace`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1490,11 +2045,11 @@ export const WorkspaceResourceApiFp = function(configuration?: Configuration) {
         /**
          * Deletes a workspace.
          * @summary Delete workspace
-         * @param {WorkspaceDeletionRequest} [workspaceDeletionRequest] 
+         * @param {WorkspaceDeletionRequest} workspaceDeletionRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serviceWorkspaceDelete(workspaceDeletionRequest?: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+        async serviceWorkspaceDelete(workspaceDeletionRequest: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.serviceWorkspaceDelete(workspaceDeletionRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['WorkspaceResourceApi.serviceWorkspaceDelete']?.[localVarOperationServerIndex]?.url;
@@ -1503,11 +2058,11 @@ export const WorkspaceResourceApiFp = function(configuration?: Configuration) {
         /**
          * Creates a new workspace for a user.
          * @summary Create workspace
-         * @param {WorkspaceCreationRequest} [workspaceCreationRequest] 
+         * @param {WorkspaceCreationRequest} workspaceCreationRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serviceWorkspacePost(workspaceCreationRequest?: WorkspaceCreationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserWorkspace>> {
+        async serviceWorkspacePost(workspaceCreationRequest: WorkspaceCreationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserWorkspace>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.serviceWorkspacePost(workspaceCreationRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['WorkspaceResourceApi.serviceWorkspacePost']?.[localVarOperationServerIndex]?.url;
@@ -1537,21 +2092,21 @@ export const WorkspaceResourceApiFactory = function (configuration?: Configurati
         /**
          * Deletes a workspace.
          * @summary Delete workspace
-         * @param {WorkspaceDeletionRequest} [workspaceDeletionRequest] 
+         * @param {WorkspaceDeletionRequest} workspaceDeletionRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceWorkspaceDelete(workspaceDeletionRequest?: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
+        serviceWorkspaceDelete(workspaceDeletionRequest: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig): AxiosPromise<boolean> {
             return localVarFp.serviceWorkspaceDelete(workspaceDeletionRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Creates a new workspace for a user.
          * @summary Create workspace
-         * @param {WorkspaceCreationRequest} [workspaceCreationRequest] 
+         * @param {WorkspaceCreationRequest} workspaceCreationRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serviceWorkspacePost(workspaceCreationRequest?: WorkspaceCreationRequest, options?: RawAxiosRequestConfig): AxiosPromise<UserWorkspace> {
+        serviceWorkspacePost(workspaceCreationRequest: WorkspaceCreationRequest, options?: RawAxiosRequestConfig): AxiosPromise<UserWorkspace> {
             return localVarFp.serviceWorkspacePost(workspaceCreationRequest, options).then((request) => request(axios, basePath));
         },
     };
@@ -1580,24 +2135,24 @@ export class WorkspaceResourceApi extends BaseAPI {
     /**
      * Deletes a workspace.
      * @summary Delete workspace
-     * @param {WorkspaceDeletionRequest} [workspaceDeletionRequest] 
+     * @param {WorkspaceDeletionRequest} workspaceDeletionRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof WorkspaceResourceApi
      */
-    public serviceWorkspaceDelete(workspaceDeletionRequest?: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig) {
+    public serviceWorkspaceDelete(workspaceDeletionRequest: WorkspaceDeletionRequest, options?: RawAxiosRequestConfig) {
         return WorkspaceResourceApiFp(this.configuration).serviceWorkspaceDelete(workspaceDeletionRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Creates a new workspace for a user.
      * @summary Create workspace
-     * @param {WorkspaceCreationRequest} [workspaceCreationRequest] 
+     * @param {WorkspaceCreationRequest} workspaceCreationRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof WorkspaceResourceApi
      */
-    public serviceWorkspacePost(workspaceCreationRequest?: WorkspaceCreationRequest, options?: RawAxiosRequestConfig) {
+    public serviceWorkspacePost(workspaceCreationRequest: WorkspaceCreationRequest, options?: RawAxiosRequestConfig) {
         return WorkspaceResourceApiFp(this.configuration).serviceWorkspacePost(workspaceCreationRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/terraform/modules/keycloak/README.md
+++ b/terraform/modules/keycloak/README.md
@@ -3,3 +3,7 @@
 This module creates a Sample Realm in Keycloak to be used by Theia Cloud.
 
 The module creates two test users, _foo_ and _bar_.
+
+The module creates admin user group `theia-cloud/admin`.
+
+The realm, test users, and admin user group are exported to be used in terraform configurations using this module.

--- a/terraform/modules/keycloak/main.tf
+++ b/terraform/modules/keycloak/main.tf
@@ -45,11 +45,19 @@ resource "keycloak_openid_client" "theia-cloud" {
   ]
 }
 
+resource "keycloak_group" "theia_cloud_admin" {
+  realm_id = keycloak_realm.theia-cloud.id
+  name     = "theia-cloud/admin"
+}
+
 resource "keycloak_openid_group_membership_protocol_mapper" "groups" {
   realm_id   = keycloak_realm.theia-cloud.id
   client_id  = keycloak_openid_client.theia-cloud.id
   name       = "groups"
   claim_name = "groups"
+  # Disable full path for group names to just get the group name as configured
+  # and avoid Keycloak prefixing them with a slash
+  full_path = false
 }
 
 resource "keycloak_openid_audience_protocol_mapper" "audience" {

--- a/terraform/modules/keycloak/outputs.tf
+++ b/terraform/modules/keycloak/outputs.tf
@@ -1,0 +1,29 @@
+
+output "realm" {
+  value = {
+    id   = keycloak_realm.theia-cloud.id
+    name = keycloak_realm.theia-cloud.realm
+  }
+}
+
+output "admin_group" {
+  value = {
+    id   = keycloak_group.theia_cloud_admin.id
+    name = keycloak_group.theia_cloud_admin.name
+  }
+}
+
+output "test_users" {
+  value = {
+    foo = {
+      id       = keycloak_user.test-user-foo.id
+      username = keycloak_user.test-user-foo.username
+      email    = keycloak_user.test-user-foo.email
+    }
+    bar = {
+      id       = keycloak_user.test-user-bar.id
+      username = keycloak_user.test-user-bar.username
+      email    = keycloak_user.test-user-bar.email
+    }
+  }
+}

--- a/terraform/test-configurations/0_minikube-setup/minikube_test_cluster.tf
+++ b/terraform/test-configurations/0_minikube-setup/minikube_test_cluster.tf
@@ -125,3 +125,12 @@ module "keycloak" {
   keycloak_test_user_bar_password = "bar"
   valid_redirect_uri              = "*"
 }
+
+# Configure user foo as admin by adding it to the admin group
+resource "keycloak_group_memberships" "admin_group_memberships" {
+  realm_id = module.keycloak.realm.id
+  group_id = module.keycloak.admin_group.id
+  members = [
+    module.keycloak.test_users.foo.username
+  ]
+}

--- a/terraform/test-configurations/test.md
+++ b/terraform/test-configurations/test.md
@@ -24,3 +24,19 @@ Pick an installation in one of below directories and run `terraform init` and `t
 - `2-02_monitor` installs a setup that allows to test the monitor (VSCode extension or Theia extension based) with and without authentication
 - `2-03_try-now_paths` installs a local version of <https://try.theia-cloud.io/> using paths instead of subdomains.
 - `2-04_try-now_paths_eager-start` installs a local version of <https://try.theia-cloud.io/> using paths and eager instead of lazy starting of pods. See its [README](./2-04_try-now_paths_eager-start/README.md) for more details.
+
+## Getting a Keycloak access token
+
+To test the service's APIs via a REST client such as Postman or Bruno, you need to provide a Bearer token to authenticate.
+You can get such a token from Keycloak with a simple CLI call using `curl` and `jq`.
+This call gets the token for test user `foo`.
+
+```sh
+curl -s --insecure --request POST \
+  --url https://$(minikube ip).nip.io/keycloak/realms/TheiaCloud/protocol/openid-connect/token \
+  --header 'content-type: application/x-www-form-urlencoded' \
+  --data grant_type=password \
+  --data client_id=theia-cloud \
+  --data username=foo \
+  --data password=foo | jq -r '.access_token'
+```


### PR DESCRIPTION
# Summary

This PR adds the concept of admin users to the Theia Cloud REST service. They are identified by a configurable admin group name in MicroProfile JWT's groups claim.
Admin only endpoints and resources can be configured via new annotation `@AdminOnly`. This is used for a new endpoint that allows updating an app definition's min and max instances. In addition an admin ping endpoint was added.
The terraform Keycloak module was extended to configure the default admin group and export realm, group, and test user infos for further usage in consuming modules.

A corresponding PR for the Helm chart allows configuring the admin group name as a value: https://github.com/eclipse-theia/theia-cloud-helm/pull/87

# How to test

- Setup Minikube using the terraform test configurations. To use a configure a custom group name for the service set value `keycloak.adminGroup` on the theia-cloud Helm chart.
  - You'll need to rename the group created by the Keycloak module manually in Keycloak's admin UI. You can find it in the TheiaCloud realm under Groups.
- You'll need an access token for the user `foo` which is configured to be an admin user by the terraform test setup
```bash
curl -s --insecure --request POST \
  --url https://$(minikube ip).nip.io/keycloak/realms/TheiaCloud/protocol/openid-connect/token \
  --header 'content-type: application/x-www-form-urlencoded' \
  --data grant_type=password \
  --data client_id=theia-cloud \
  --data username=foo \
  --data password=foo | jq .access_token
```
- Use this as a Bearer token in your request
- A GET request to `https://$(minikube ip).nip.io/service/service/admin/asdfghjkl` should return true with a token for user foo. It should return `403` for user bar because bar is not an admin user
- Update an app definition at endpoint PATCH `$(minikube ip).nip.io/service/service/admin/appdefinition/<appdef-name>` . The payload is a JSON object like so:
```json
{
  "appId": "asdfghjkl",
  "minInstances": 2,
  "maxInstances": 4
}
```

# Implementation details

<details><summary>Implementation details</summary>

## Add admin user support via annotation 

- Introduce the `@AdminOnly` annotation to mark REST resources or methods as accessible only to admin users.
- Implement AdminOnlyFilter that intercepts requests and aborts non-admin users with a 403 Forbidden response.
- Update ApplicationProperties to include a configurable admin group name property ("theia.cloud.auth.admin.group")
  with a default value of "theia-cloud/admin".
- Enhance TheiaCloudUser by adding an admin flag.
- Modify TheiaCloudUserProducer to derive the admin status from the MicroProfile JWT's groups claim.
- Add tests for the new admin-only filter, properties, and user producer functionality.
- Extend service Dockerfile to allow configuring the admin group name via environment variable.

## Add admin endpoint to update app def's min/max instances

- Add new resource AdminAppDefinitionAdminResource for all admin endpoints regarding app definitions
- Minor extensions in K8SUtil, AppDefinitionSpec to allow editing min/max instances
- Add tests for AdminAppDefintionAdminResource
- Add RootAdminResource with a ping endpoint that only returns if the user is an admin

## terrafom: Add admin user group and outputs for Keycloak module 

Extend Keycloak terraform module:
- Define an admin group with the default name
- Export realm, admin group and test users via outputs

Test setup:
- Add test user foo to the admin group

## fix: Update Keycloak URL in tasks.json to include realm path 

This is required for the Quarkus dev server to discover the OIDC config.
Also see the official documentation: <https://quarkus.io/guides/security-oidc-configuration-properties-reference#quarkus-oidc_quarkus-oidc-auth-server-url>
</details>