### PR TITLE
Include uid in session label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## [1.1.0] - estimated 2025-02
+## [1.1.0] - estimated 2025-04
 
 - [theia] Introduce new folder `theia` for all theia extensions and an example app to test these [#389](https://github.com/eclipse-theia/theia-cloud/pull/389)
 - [node/monitor-theia] Move Theia monitor extension to `theia/extensions/monitor-theia` [#389](https://github.com/eclipse-theia/theia-cloud/pull/389)
 - [theia/extensions/monitor-theia] Update Theia dependencies to `^1.55.0` [#389](https://github.com/eclipse-theia/theia-cloud/pull/389)
 - [ci] Add Theia CI workflow, add reusable Theia extension publish workflow [#389](https://github.com/eclipse-theia/theia-cloud/pull/388)
+
+### Breaking Changes in 1.1.0
+
+- [java/common] Changed `LabelsUtil.createSessionLabels` to accept `AppDefinition` instead of `AppDefinitionSpec`
 
 ## [1.0.1] - 2025-03-24
 

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/LabelsUtil.java
@@ -1,3 +1,18 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
 package org.eclipse.theia.cloud.common.util;
 
 import java.util.HashMap;
@@ -5,7 +20,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
+import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
+import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
 
 public class LabelsUtil {
@@ -22,6 +38,7 @@ public class LabelsUtil {
     public static final String LABEL_KEY_USER = LABEL_CUSTOM_PREFIX + "/user";
     public static final String LABEL_KEY_APPDEF = LABEL_CUSTOM_PREFIX + "/app-definition";
     public static final String LABEL_KEY_SESSION_NAME = LABEL_CUSTOM_PREFIX + "/session";
+    public static final String LABEL_KEY_SESSION_UUID = LABEL_CUSTOM_PREFIX + "/session-uuid";
 
     private static final int MAX_LABEL_LENGTH = 63;
 
@@ -33,24 +50,28 @@ public class LabelsUtil {
         return value;
     }
 
-    public static Map<String, String> createSessionLabels(SessionSpec sessionSpec,
-            AppDefinitionSpec appDefinitionSpec) {
+    public static Map<String, String> createSessionLabels(Session session, AppDefinition appDefinition) {
+        SessionSpec sessionSpec = session.getSpec();
         Map<String, String> labels = new HashMap<>();
+        String sanitizedUser = sessionSpec.getUser().replaceAll("@", "_at_").replaceAll("[^a-zA-Z0-9]", "_");
+
         labels.put(LABEL_KEY_SESSION, LABEL_VALUE_SESSION);
         labels.put(LABEL_KEY_THEIACLOUD, LABEL_VALUE_THEIACLOUD);
-        String sanitizedUser = sessionSpec.getUser().replaceAll("@", "_at_").replaceAll("[^a-zA-Z0-9]", "_");
         labels.put(LABEL_KEY_USER, truncateLabelValue(sanitizedUser));
-        labels.put(LABEL_KEY_APPDEF, truncateLabelValue(appDefinitionSpec.getName()));
+        labels.put(LABEL_KEY_APPDEF, truncateLabelValue(appDefinition.getSpec().getName()));
         labels.put(LABEL_KEY_SESSION_NAME, truncateLabelValue(sessionSpec.getName()));
+        labels.put(LABEL_KEY_SESSION_UUID, truncateLabelValue(session.getMetadata().getUid()));
+
         return labels;
     }
 
     /**
-     * Returns the set of label keys that are specific to a specific session, i.e. the user and session name keys.
+     * Returns the set of label keys that are specific to a specific session, i.e. the user, session name, and session
+     * UUID keys.
      * 
      * @return The session specific label keys.
      */
     public static Set<String> getSessionSpecificLabelKeys() {
-        return Set.of(LABEL_KEY_SESSION_NAME, LABEL_KEY_USER);
+        return Set.of(LABEL_KEY_SESSION_NAME, LABEL_KEY_SESSION_UUID, LABEL_KEY_USER);
     }
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.client.TheiaCloudClient;
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
-import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinitionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
 import org.eclipse.theia.cloud.common.util.JavaUtil;
@@ -136,8 +135,7 @@ public class EagerSessionHandler implements SessionHandler {
                             labels = new HashMap<>();
                             service.getMetadata().setLabels(labels);
                         }
-                        Map<String, String> newLabels = LabelsUtil.createSessionLabels(spec,
-                                appDefinition.get().getSpec());
+                        Map<String, String> newLabels = LabelsUtil.createSessionLabels(session, appDefinition.get());
                         labels.putAll(newLabels);
                         return service;
                     });
@@ -321,13 +319,12 @@ public class EagerSessionHandler implements SessionHandler {
                     + " found. Thus, no cleanup is needed because associated resources are deleted by Kubernets garbage collecion."));
             return true;
         }
-        AppDefinitionSpec appDefinitionSpec = appDefinition.get().getSpec();
 
         // Find service by first filtering all services by the session's corresponding session labels (as added in
         // sessionCreated) and then checking if the service has an owner reference to the session
         String sessionResourceName = session.getMetadata().getName();
         String sessionResourceUID = session.getMetadata().getUid();
-        Map<String, String> sessionLabels = LabelsUtil.createSessionLabels(spec, appDefinitionSpec);
+        Map<String, String> sessionLabels = LabelsUtil.createSessionLabels(session, appDefinition.get());
         // Filtering by withLabels(sessionLabels) because the method requires an exact match of the labels.
         // Additional labels on the service prevent a match and the service has an additional app label.
         // Thus, filter by each session label separately.

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
@@ -160,7 +160,7 @@ public class LazySessionHandler implements SessionHandler {
         AppDefinitionSpec appDefinitionSpec = appDefinition.getSpec();
 
         /* label maps */
-        Map<String, String> labelsToAdd = LabelsUtil.createSessionLabels(session.getSpec(), appDefinitionSpec);
+        Map<String, String> labelsToAdd = LabelsUtil.createSessionLabels(session, appDefinition);
 
         if (hasMaxInstancesReached(appDefinition, session, correlationId)) {
             client.sessions().updateStatus(correlationId, session, s -> {


### PR DESCRIPTION
Since labels are potentially cropped, including the uid in the session label provides a reliable substring.