### PR TITLE
Add publish scripts for config-store extension; Fix name lengths

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,10 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.32.1, v1.31.5, v1.30.9, v1.29.13] # https://kubernetes.io/releases/
+        kubernetes: [v1.33.3, v1.32.7, v1.31.11] # https://kubernetes.io/releases/
         paths: [true, false]
         ephemeral: [true, false]
         keycloak: [true, false]
+        exclude:
+          # Non-ephemeral sessions only make sense with keycloak
+          - ephemeral: false
+            keycloak: false
     steps:
       - name: Set Helm Branch for Scheduled Runs
         if: ${{ github.event_name == 'schedule' }}
@@ -156,10 +160,23 @@ jobs:
           export MATRIX_KEYCLOAK=${{ matrix.keycloak }}
           npm run ui-tests -w e2e-tests
 
+      - name: Print Debug logs
+        if: failure()
+        run: |
+          echo "=== Service Deployment Logs ==="
+          kubectl logs -n theia-cloud deployment/service-deployment --tail=100
+          echo ""
+          echo "=== Operator Deployment Logs (All Pods) ==="
+          for pod in $(kubectl get pods -n theia-cloud -l app=operator -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- Logs from pod: $pod ---"
+            kubectl logs -n theia-cloud $pod --tail=100
+            echo ""
+          done
+
       - name: Upload Playwright test failure screenshots
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-failure-screenshots
+          name: test-failure-screenshots-k8s-${{ matrix.kubernetes }}-paths-${{ matrix.paths }}-ephemeral-${{ matrix.ephemeral }}-keycloak-${{ matrix.keycloak }}
           path: theia-cloud/node/e2e-tests/test-results/**/*.png
           retention-days: 7

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/TheiaCloudClient.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/client/TheiaCloudClient.java
@@ -81,7 +81,7 @@ public interface TheiaCloudClient extends NamespacedKubernetesClient {
         try (final KubernetesClient client = new KubernetesClientBuilder().build()) {
             ServiceList svcList = client.services().inNamespace(namespace()).list();
             for (Service svc : svcList.getItems()) {
-                if (svc.getMetadata().getName().endsWith("-internal")) {
+                if (svc.getMetadata().getName().endsWith("-int")) {
                     continue;
                 }
                 for (OwnerReference ownerReference : svc.getMetadata().getOwnerReferences()) {
@@ -98,7 +98,7 @@ public interface TheiaCloudClient extends NamespacedKubernetesClient {
         try (final KubernetesClient client = new KubernetesClientBuilder().build()) {
             ServiceList svcList = client.services().inNamespace(namespace()).list();
             for (Service svc : svcList.getItems()) {
-                if (!svc.getMetadata().getName().endsWith("-internal")) {
+                if (!svc.getMetadata().getName().endsWith("-int")) {
                     continue;
                 }
                 for (OwnerReference ownerReference : svc.getMetadata().getOwnerReferences()) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
@@ -278,9 +278,9 @@ public class EagerSessionHandler implements SessionHandler {
         List<Service> existingServices = K8sUtil.getExistingServices(client, namespace, appDefinitionResourceName,
                 appDefinitionResourceUID);
 
-        // Filter for external services (those without "-internal" suffix)
+        // Filter for external services (those without "-int" suffix)
         List<Service> existingExternalServices = existingServices.stream()
-                .filter(service -> !service.getMetadata().getName().endsWith("-internal")).collect(Collectors.toList());
+                .filter(service -> !service.getMetadata().getName().endsWith("-int")).collect(Collectors.toList());
 
         Optional<Service> alreadyReservedService = TheiaCloudServiceUtil.getServiceOwnedBySession(sessionResourceName,
                 sessionResourceUID, existingExternalServices);
@@ -313,9 +313,9 @@ public class EagerSessionHandler implements SessionHandler {
         List<Service> existingServices = K8sUtil.getExistingServices(client, namespace, appDefinitionResourceName,
                 appDefinitionResourceUID);
 
-        // Filter for internal services (those with "-internal" suffix)
+        // Filter for internal services (those with "-int" suffix)
         List<Service> existingInternalServices = existingServices.stream()
-                .filter(service -> service.getMetadata().getName().endsWith("-internal")).collect(Collectors.toList());
+                .filter(service -> service.getMetadata().getName().endsWith("-int")).collect(Collectors.toList());
 
         Optional<Service> alreadyReservedService = TheiaCloudServiceUtil.getServiceOwnedBySession(sessionResourceName,
                 sessionResourceUID, existingInternalServices);
@@ -418,9 +418,9 @@ public class EagerSessionHandler implements SessionHandler {
 
         // Separate external and internal services
         List<Service> externalServices = services.stream()
-                .filter(service -> !service.getMetadata().getName().endsWith("-internal")).collect(Collectors.toList());
+                .filter(service -> !service.getMetadata().getName().endsWith("-int")).collect(Collectors.toList());
         List<Service> internalServices = services.stream()
-                .filter(service -> service.getMetadata().getName().endsWith("-internal")).collect(Collectors.toList());
+                .filter(service -> service.getMetadata().getName().endsWith("-int")).collect(Collectors.toList());
 
         if (externalServices.size() != 1) {
             LOGGER.error(formatLogMessage(correlationId, "Expected exactly one external service owned by session "

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
@@ -55,11 +55,11 @@ public final class TheiaCloudServiceUtil {
     }
 
     public static String getInternalServiceName(Session session) {
-        return NamingUtil.createName(session) + "-internal";
+        return NamingUtil.createNameWithSuffix(session, "int");
     }
 
     public static String getInternalServiceName(AppDefinition appDefinition, int instance) {
-        return NamingUtil.createName(appDefinition, instance) + "-internal";
+        return NamingUtil.createNameWithSuffix(appDefinition, instance, "int");
     }
 
     public static Integer getId(String correlationId, AppDefinition appDefinition, Service service) {

--- a/theia/extensions/config-store/package.json
+++ b/theia/extensions/config-store/package.json
@@ -37,7 +37,10 @@
     "clean": "rimraf lib",
     "build": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint -c ../../.eslintrc.js --ext .ts ./src"
+    "lint": "eslint -c ../../.eslintrc.js --ext .ts ./src",
+    "prepublishOnly": "npm run build",
+    "publish:next": "npm pkg set version=`node --print \"require('./package.json').version\"`.`git rev-parse --short HEAD` && npm publish --tag next",
+    "publish:latest": "npm publish --tag latest"
   },
   "theiaExtensions": [
     {


### PR DESCRIPTION
* add publish:next and publish:latest scripts for versioning and publishing with tags
* add prepublishOnly script to ensure the extension is built before publishing
* also update e2e-test workflow
* prevent names from getting too long

closes #388