### PR TITLE
fix: Use ingress path type `ImplementationSpecific` instead of `Prefix`

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/AddedHandlerUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/AddedHandlerUtil.java
@@ -88,6 +88,7 @@ public final class AddedHandlerUtil {
     public static final String FILENAME_AUTHENTICATED_EMAILS_LIST = "authenticated-emails-list";
 
     public static final String INGRESS_REWRITE_PATH = "(/|$)(.*)";
+    public static final String INGRESS_PATH_TYPE = "ImplementationSpecific";
 
     private static final HostnameVerifier ALL_GOOD_HOSTNAME_VERIFIER = new HostnameVerifier() {
         @Override

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/EagerSessionHandler.java
@@ -363,7 +363,7 @@ public class EagerSessionHandler implements SessionHandler {
         HTTPIngressPath httpIngressPath = new HTTPIngressPath();
         http.getPaths().add(httpIngressPath);
         httpIngressPath.setPath(path + AddedHandlerUtil.INGRESS_REWRITE_PATH);
-        httpIngressPath.setPathType("Prefix");
+        httpIngressPath.setPathType(AddedHandlerUtil.INGRESS_PATH_TYPE);
 
         IngressBackend ingressBackend = new IngressBackend();
         httpIngressPath.setBackend(ingressBackend);

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
@@ -553,7 +553,7 @@ public class LazySessionHandler implements SessionHandler {
                 HTTPIngressPath httpIngressPath = new HTTPIngressPath();
                 http.getPaths().add(httpIngressPath);
                 httpIngressPath.setPath(path + AddedHandlerUtil.INGRESS_REWRITE_PATH);
-                httpIngressPath.setPathType("Prefix");
+                httpIngressPath.setPathType(AddedHandlerUtil.INGRESS_PATH_TYPE);
 
                 IngressBackend ingressBackend = new IngressBackend();
                 httpIngressPath.setBackend(ingressBackend);


### PR DESCRIPTION
With later NginX versions, using regex-style syntax in ingress paths is no longer allowed for path type `Prefix`. Thus, switch to `ImplementationSpecific`.

Part of https://github.com/eclipse-theia/theia-cloud/issues/447
