### PR TITLE
ci: Configure npm workflows to use trusted publishing

### DIFF
--- a/.github/workflows/cd-config-store-theia.yml
+++ b/.github/workflows/cd-config-store-theia.yml
@@ -26,5 +26,3 @@ jobs:
       id-token: write
     with:
       package_workspace: extensions/config-store
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cd-monitor-theia.yml
+++ b/.github/workflows/cd-monitor-theia.yml
@@ -26,5 +26,3 @@ jobs:
       id-token: write
     with:
       package_workspace: extensions/monitor-theia
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci-node-common.yml
+++ b/.github/workflows/ci-node-common.yml
@@ -28,5 +28,3 @@ jobs:
       id-token: write
     with:
       package_workspace: common
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/reusable-npm.yml
+++ b/.github/workflows/reusable-npm.yml
@@ -76,12 +76,10 @@ jobs:
         if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true'
         run: npm run publish:next -w ${{ inputs.package_workspace }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Publish latest version
         if: github.event_name == 'release'
         run: npm run publish:latest -w ${{ inputs.package_workspace }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/reusable-theia-extension.yml
+++ b/.github/workflows/reusable-theia-extension.yml
@@ -54,12 +54,10 @@ jobs:
         if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true'
         run: npm run publish:next -w ${{ inputs.package_workspace }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Publish latest version
         if: github.event_name == 'release'
         run: npm run publish:latest -w ${{ inputs.package_workspace }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
I already adapted the NPM package config to configure the corresponding workflows as trusted.

Remove usage of NPM token. id-token write permission was already set from configuring npm provenance earlier.

Part of #454