### PR TITLE
ci: Remove obsolete npm-token secret input from npm and theia workflows

### DIFF
--- a/.github/workflows/reusable-npm.yml
+++ b/.github/workflows/reusable-npm.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: string
         description: The package's workspace path relative to the node directory.
-    secrets:
-      npm-token:
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-theia-extension.yml
+++ b/.github/workflows/reusable-theia-extension.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: string
         description: The package's workspace path relative to the node directory.
-    secrets:
-      npm-token:
-        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
With moving to npm-trusted publishing the npm-token is no longer needed as an input for the reusable npm and theia workflows.