### PR TITLE
CI: bump minikube and harden e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d # v2.14.0
         with:
-          minikube version: v1.36.0
+          minikube version: v1.37.0
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: "--force"
@@ -75,8 +75,11 @@ jobs:
 
       - name: Patch Ingress to allow snippet annotations and restart
         run: |
-          kubectl -n ingress-nginx patch cm ingress-nginx-controller --patch '{"data":{"allow-snippet-annotations":"true"}}'
-          kubectl -n ingress-nginx delete pod -l app.kubernetes.io/name=ingress-nginx
+          kubectl -n ingress-nginx patch configmap ingress-nginx-controller \
+            --type merge \
+            -p '{"data":{"allow-snippet-annotations":"true","annotations-risk-level":"Critical"}}'
+          kubectl -n ingress-nginx rollout restart deployment ingress-nginx-controller
+          kubectl -n ingress-nginx rollout status deployment ingress-nginx-controller --timeout=90s
 
       # we use the none driver, so minikube should see the same images on the host
       - name: Build Theia Cloud Images
@@ -99,9 +102,24 @@ jobs:
           echo "INGRESS_HOST=$INGRESS_HOST" >> $GITHUB_ENV
 
       - name: Run Terraform
+        id: terraform_apply
+        continue-on-error: true
         run: |
           cd theia-cloud/terraform/ci-configurations
           terraform init
+          terraform apply \
+            -var="ingress_ip=${{ env.INGRESS_HOST }}" \
+            -var="use_paths=${{ matrix.paths }}" \
+            -var="use_ephemeral_storage=${{ matrix.ephemeral }}" \
+            -var="enable_keycloak=${{ matrix.keycloak }}" \
+            -auto-approve
+
+      - name: Retry Terraform Apply
+        if: steps.terraform_apply.outcome == 'failure'
+        run: |
+          echo "Waiting 30 seconds before retrying..."
+          sleep 30
+          cd theia-cloud/terraform/ci-configurations
           terraform apply \
             -var="ingress_ip=${{ env.INGRESS_HOST }}" \
             -var="use_paths=${{ matrix.paths }}" \


### PR DESCRIPTION
This should fix the e2e tests workflow and make it a bit more stable overall. Test run: https://github.com/eclipse-theia/theia-cloud/actions/runs/19361702188/job/55394989062

* E2E: update minikube version v1.36.0 -> v1.37.0 (fixes issues with Kubernetes 1.34)
* Ingress: patch `ingress-nginx-controller` ConfigMap via merge; set `allow-snippet-annotations="true"` and `annotations-risk-level="Critical"`; restart deployment via rollout and wait for status (fixes issues with newer nginx ingress controller)
* Terraform: allow initial `terraform apply` to fail; add 30s wait and retry with same variables (makes workflow more resilient wrt timeouts, etc.)