### PR TITLE
Use unprivileged NGINX image for landing page container

### DIFF
--- a/dockerfiles/landing-page/Dockerfile
+++ b/dockerfiles/landing-page/Dockerfile
@@ -15,7 +15,7 @@ RUN npm ci && \
   chmod 644 /app/landing-page/dist/favicon.ico
 
 # production stage
-FROM nginx:stable-alpine as production-stage
+FROM nginxinc/nginx-unprivileged:stable-alpine as production-stage
 COPY --from=build-stage /app/landing-page/dist /usr/share/nginx/html
-EXPOSE 80
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
* Switch `dockerfiles/landing-page/Dockerfile` production stage to `nginxinc/nginx-unprivileged:stable-alpine` to avoid running as root
* Expose port `8080` to match the unprivileged image default listener

Related https://github.com/eclipse-theia/theia-cloud-helm/pull/102