### PR TITLE
Make oauth2-proxy image configurable via --oAuth2ProxyImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- [java/operator] Add `--oAuth2ProxyImage` operator argument to override the full oauth2-proxy image path (defaults to `quay.io/oauth2-proxy/oauth2-proxy`). This enables pulling the image from a private registry in air-gapped or corporate networks, instead of only configuring the tag via `--oAuth2ProxyVersion`.
+
 ## [1.2.0] - 2026-04-09
 
 - [java/operator] Fix ingress rules not being fully removed on session deletion [#456](https://github.com/eclipse-theia/theia-cloud/pull/456)

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
@@ -123,7 +123,11 @@ public class TheiaCloudOperatorArguments {
     private boolean continueOnException;
 
     @Option(names = {
-            "--oAuth2ProxyVersion" }, description = "The version to use of the quay.io/oauth2-proxy/oauth2-proxy image.", required = false, defaultValue = "latest")
+            "--oAuth2ProxyImage" }, description = "The image (without tag) to use for the oauth2-proxy container. Override this to pull from a private registry in air-gapped or corporate networks.", required = false, defaultValue = "quay.io/oauth2-proxy/oauth2-proxy")
+    private String oAuth2ProxyImage;
+
+    @Option(names = {
+            "--oAuth2ProxyVersion" }, description = "The version (image tag) to use of the oauth2-proxy image.", required = false, defaultValue = "latest")
     private String oAuth2ProxyVersion;
 
     @Option(names = {
@@ -238,6 +242,10 @@ public class TheiaCloudOperatorArguments {
         return continueOnException;
     }
 
+    public String getOAuth2ProxyImage() {
+        return oAuth2ProxyImage;
+    }
+
     public String getOAuth2ProxyVersion() {
         return oAuth2ProxyVersion;
     }
@@ -294,6 +302,7 @@ public class TheiaCloudOperatorArguments {
         result = prime * result + (useKeycloak ? 1231 : 1237);
         result = prime * result + (usePaths ? 1231 : 1237);
         result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
+        result = prime * result + ((oAuth2ProxyImage == null) ? 0 : oAuth2ProxyImage.hashCode());
         result = prime * result + ((oAuth2ProxyVersion == null) ? 0 : oAuth2ProxyVersion.hashCode());
         result = prime * result + ((ingressPathSuffix == null) ? 0 : ingressPathSuffix.hashCode());
         return result;
@@ -397,6 +406,11 @@ public class TheiaCloudOperatorArguments {
                 return false;
         } else if (!wondershaperImage.equals(other.wondershaperImage))
             return false;
+        if (oAuth2ProxyImage == null) {
+            if (other.oAuth2ProxyImage != null)
+                return false;
+        } else if (!oAuth2ProxyImage.equals(other.oAuth2ProxyImage))
+            return false;
         if (oAuth2ProxyVersion == null) {
             if (other.oAuth2ProxyVersion != null)
                 return false;
@@ -422,7 +436,8 @@ public class TheiaCloudOperatorArguments {
                 + ", keycloakClientId=" + keycloakClientId + ", leaderLeaseDuration=" + leaderLeaseDuration
                 + ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
                 + ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException
-                + ", oAuth2ProxyVersion=" + oAuth2ProxyVersion + ", ingressPathSuffix=" + ingressPathSuffix + "]";
+                + ", oAuth2ProxyImage=" + oAuth2ProxyImage + ", oAuth2ProxyVersion=" + oAuth2ProxyVersion
+                + ", ingressPathSuffix=" + ingressPathSuffix + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
@@ -65,6 +65,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_MONITOR_PORT = "placeholder-monitor-port";
     public static final String PLACEHOLDER_MONITOR_PORT_ENV = "placeholder-monitor-env-port";
     public static final String PLACEHOLDER_ENABLE_ACTIVITY_TRACKER = "placeholder-enable-activity-tracker";
+    public static final String PLACEHOLDER_OAUTH2_PROXY_IMAGE = "placeholder-oauth2-proxy-image";
     public static final String PLACEHOLDER_OAUTH2_PROXY_VERSION = "placeholder-oauth2-proxy-version";
 
     protected static final String DEFAULT_UID = "1000";
@@ -82,6 +83,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
         replacements.putAll(getAppDefinitionData(appDefinition));
         replacements.putAll(getEnvironmentVariables(appDefinition, instance));
         replacements.putAll(getInstanceData(appDefinition, instance));
+        replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getOAuth2ProxyImage());
         replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getOAuth2ProxyVersion());
         return replacements;
     }
@@ -93,6 +95,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
         replacements.putAll(getAppDefinitionData(appDefinition));
         replacements.putAll(getEnvironmentVariables(appDefinition, session));
         replacements.putAll(getSessionData(session));
+        replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getOAuth2ProxyImage());
         replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getOAuth2ProxyVersion());
         return replacements;
     }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:placeholder-oauth2-proxy-version
+          image: placeholder-oauth2-proxy-image:placeholder-oauth2-proxy-version
           imagePullPolicy: Always
           args:
             - --config=/etc/oauth2-proxy.cfg


### PR DESCRIPTION
## What it does

Closes #490 

The operator previously hardcoded the `quay.io/oauth2-proxy/oauth2-proxy` registry
in `templateDeployment.yaml`, allowing only the tag to be configured via
`--oAuth2ProxyVersion`. This prevented deploying Theia Cloud in air-gapped or
corporate networks where images must be pulled from a private registry
(e.g. Nexus, Artifactory).

This PR adds a new operator argument `--oAuth2ProxyImage` that overrides the full
image path (registry + repository) for the oauth2-proxy container, while
`--oAuth2ProxyVersion` continues to control the tag.

## Changes

- `TheiaCloudOperatorArguments`: new `--oAuth2ProxyImage` option
  (default `quay.io/oauth2-proxy/oauth2-proxy`), plus getter and updated
  `hashCode`/`equals`/`toString`.
- `DefaultDeploymentTemplateReplacements`: new `placeholder-oauth2-proxy-image`
  placeholder, populated from the new argument in both `getReplacements` methods.
- `templateDeployment.yaml`: image line changed from
  `quay.io/oauth2-proxy/oauth2-proxy:placeholder-oauth2-proxy-version`
  to `placeholder-oauth2-proxy-image:placeholder-oauth2-proxy-version`.
- `CHANGELOG.md`: added entry under Unreleased.

## Backwards compatibility

Fully backwards compatible. The default value reproduces the previous behavior,
so existing deployments are unaffected. Users in restricted networks can now set
e.g. `--oAuth2ProxyImage=nexus.corp.local/oauth2-proxy/oauth2-proxy`.

## Follow-up

The Helm chart lives in the separate repository. A companion
change is needed there to expose this as a value (e.g. `operator.oAuth2ProxyImage`)
and pass it through to the operator. Happy to open that PR as well.

