### PR TITLE
ci: fix config-store publish and its workflow path filter

### DIFF
--- a/.github/workflows/cd-config-store-theia.yml
+++ b/.github/workflows/cd-config-store-theia.yml
@@ -8,7 +8,7 @@ on:
       - "theia/yarn.lock"
       - "theia/extensions/config-store/**"
       # Publish when a workflow has changed (this is needed to detect version updates)
-      - ".github/workflows/cd-config-store.yml"
+      - ".github/workflows/cd-config-store-theia.yml"
       - ".github/workflows/reusable-theia-extension.yml"
   release:
     types:

--- a/theia/extensions/config-store/package.json
+++ b/theia/extensions/config-store/package.json
@@ -33,7 +33,7 @@
     "typescript": "~5.9.3"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "npm run clean && npm run build",
     "clean": "rimraf lib",
     "build": "tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
Align the config-store extension's `prepare` script with the monitor-theia extension to no longer use yarn in its `prepare` script.
This solves the publish step not having a dummy npm token which is required by yarn since actions/setup-node@v7.
It should not have one because trusted publishing is used.

Also correct the workflow's own path filter, which referenced cd-config-store.yml instead of cd-config-store-theia.yml and therefore never triggered on changes to this workflow.